### PR TITLE
Upgrade the dependencies, particularly es2015-native-modules, which is now deprecated.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": ["es2015-native-modules", "react"],
+  "presets": [["es2015", {"modules": false}], "react"],
   "plugins": ["transform-class-properties"]
 }

--- a/package.json
+++ b/package.json
@@ -11,25 +11,25 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "babel-core": "^6.7.2",
-    "babel-loader": "^6.2.4",
-    "babel-plugin-transform-class-properties": "^6.6.0",
-    "babel-plugin-transform-runtime": "^6.6.0",
-    "babel-preset-es2015-native-modules": "^6.6.0",
+    "babel-core": "^6.14.0",
+    "babel-loader": "^6.2.5",
+    "babel-plugin-transform-class-properties": "^6.11.5",
+    "babel-plugin-transform-runtime": "^6.15.0",
+    "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.5.0",
-    "css-loader": "^0.23.1",
-    "file-loader": "^0.8.5",
-    "style-loader": "^0.13.0",
-    "webpack": "^2.1.0-beta.4",
-    "webpack-dev-server": "^2.0.0-beta"
+    "css-loader": "^0.24.0",
+    "file-loader": "^0.9.0",
+    "style-loader": "^0.13.1",
+    "webpack": "^2.1.0-beta.21",
+    "webpack-dev-server": "^2.1.0-beta.2"
   },
   "dependencies": {
-    "babel-runtime": "^6.6.1",
-    "es6-promise": "^3.1.2",
-    "react": "^15.0.0-rc.1",
-    "react-dom": "^15.0.0-rc.1",
-    "react-redux": "^4.4.0",
-    "redux": "^3.3.1",
+    "babel-runtime": "^6.11.6",
+    "es6-promise": "^3.2.1",
+    "react": "^15.3.1",
+    "react-dom": "^15.3.1",
+    "react-redux": "^4.4.5",
+    "redux": "^3.5.2",
     "redux-thunk": "^2.0.1"
   }
 }


### PR DESCRIPTION
See the deprecation notice here: https://www.npmjs.com/package/babel-preset-es2015-native-modules
