### PR TITLE
Fixing the action type for the deleteTransaction action creator.

### DIFF
--- a/client/actions/index.js
+++ b/client/actions/index.js
@@ -12,7 +12,7 @@ function createTransaction(transaction) {
 
 export function deleteTransaction(id) {
   return {
-    type: ADD_TRANSACTION,
+    type: DELETE_TRANSACTION,
     id
   };
 }


### PR DESCRIPTION
As discussed on Twitter, simple fix for the action type used in the deleteTransaction action creator.

Great work on this - great to have up to date examples of React / Redux and Webpack to play with.