### PR TITLE
Adding hot reloading to the Webpack config

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,12 +1,11 @@
 {
 	"env": {
 		"production": {
-			"presets": [["es2015", { "modules": false }], "react"],
-			"plugins": ["transform-class-properties"]
+			"presets": [["es2015", { "modules": false }], "react"]
 		},
 		"development": {
-			"presets": [["es2015", { "modules": false }], "react", "react-hmre"],
-			"plugins": ["transform-class-properties"]
+			"presets": [["es2015", { "modules": false }], "react", "react-hmre"]
 		}
 	},
+  "plugins": ["transform-class-properties"]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,12 @@
+{
+	"env": {
+		"production": {
+			"presets": [["es2015", { "modules": false }], "react"],
+			"plugins": ["transform-class-properties"]
+		},
+		"development": {
+			"presets": [["es2015", { "modules": false }], "react", "react-hmre"],
+			"plugins": ["transform-class-properties"]
+		}
+	},
+}

--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": [["es2015", { "modules": false }], "react"],
+  "presets": [["es2015", { "modules": false }], "react", "react-hmre"],
   "plugins": ["transform-class-properties"]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": [["es2015", { "modules": false }], "react", "react-hmre"],
-  "plugins": ["transform-class-properties"]
-}

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,20 +1,20 @@
-extends: 
+extends:
   eslint-config-airbnb
 
-parser: 
+parser:
   babel-eslint
 
 settings:
   ecmascript: 6
 
-ecmaFeatures: 
+ecmaFeatures:
   jsx: true
   modules: true
   destructuring: true
   classes: true
   forOf: true
   blockBindings: true
-  arrowFunctions: true 
+  arrowFunctions: true
 
 env:
   browser: true
@@ -26,3 +26,4 @@ rules:
   comma-dangle: 0
   no-console: 0
   no-param-reassign: 0
+  linebreak-style: 0

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "webpack-dev-server --hot --inline --config webpack.config.js",
+    "start": "webpack-dev-server --config webpack.config.js",
     "prod": "node build.js production server",
     "build": "node build.js production"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "webpack-dev-server --config webpack.config.js",
+    "start": "webpack-dev-server --hot --inline --config webpack.config.js",
     "prod": "node build.js production server",
     "build": "node build.js production"
   },
@@ -18,6 +18,7 @@
     "babel-plugin-transform-runtime": "^6.6.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.5.0",
+    "babel-preset-react-hmre": "^1.1.1",
     "css-loader": "0.14.5",
     "file-loader": "^0.8.5",
     "style-loader": "^0.13.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "babel-preset-react-hmre": "^1.1.1",
     "css-loader": "0.14.5",
     "file-loader": "^0.8.5",
-    "style-loader": "^0.13.0",
+    "style-loader": "^0.13.0"
   },
   "dependencies": {
     "babel-runtime": "^6.6.1",
@@ -32,6 +32,6 @@
     "redux": "^3.3.1",
     "redux-thunk": "^2.0.1",
     "webpack": "^2.1.0-beta.26",
-    "webpack-dev-server": "^2.1.0-beta.10",
+    "webpack-dev-server": "^2.1.0-beta.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,6 @@
     "css-loader": "0.14.5",
     "file-loader": "^0.8.5",
     "style-loader": "^0.13.0",
-    "webpack": "^2.1.0-beta.26",
-    "webpack-dev-server": "^2.1.0-beta.10"
   },
   "dependencies": {
     "babel-runtime": "^6.6.1",
@@ -32,6 +30,8 @@
     "react-dom": "^15.3.0",
     "react-redux": "^4.4.0",
     "redux": "^3.3.1",
-    "redux-thunk": "^2.0.1"
+    "redux-thunk": "^2.0.1",
+    "webpack": "^2.1.0-beta.26",
+    "webpack-dev-server": "^2.1.0-beta.10",
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ const isProd = nodeEnv === 'production';
 const sourcePath = path.join(__dirname, './client');
 const staticsPath = path.join(__dirname, './static');
 
-let babelPresets = [['es2015', { 'modules': false }], 'react'];
+const babelPresets = [['es2015', { modules: false }], 'react'];
 
 const plugins = [
   new webpack.optimize.CommonsChunkPlugin({
@@ -103,7 +103,7 @@ module.exports = {
       'node_modules'
     ]
   },
-  plugins: plugins,
+  plugins,
   devServer: {
     contentBase: './client',
     historyApiFallback: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,8 @@ const isProd = nodeEnv === 'production';
 const sourcePath = path.join(__dirname, './client');
 const staticsPath = path.join(__dirname, './static');
 
+let babelPresets = [['es2015', { 'modules': false }], 'react'];
+
 const plugins = [
   new webpack.optimize.CommonsChunkPlugin({
     name: 'vendor',
@@ -16,7 +18,6 @@ const plugins = [
   new webpack.DefinePlugin({
     'process.env': { NODE_ENV: JSON.stringify(nodeEnv) }
   }),
-  new webpack.HotModuleReplacementPlugin(),
   new webpack.NamedModulesPlugin(),
 ];
 
@@ -44,6 +45,11 @@ if (isProd) {
       },
     })
   );
+} else {
+  plugins.push(
+    new webpack.HotModuleReplacementPlugin()
+  );
+  babelPresets.push('react-hmre');
 }
 
 module.exports = {
@@ -79,8 +85,14 @@ module.exports = {
         test: /\.(js|jsx)$/,
         exclude: /node_modules/,
         use: [
-          'babel-loader'
-        ]
+          { loader: 'babel-loader',
+            query: {
+              babelrc: false,
+              presets: babelPresets,
+              plugins: ['transform-class-properties'],
+            }
+          }
+        ],
       },
     ],
   },
@@ -98,7 +110,7 @@ module.exports = {
     port: 3000,
     compress: isProd,
     stats: { colors: true },
-    inline: true,
-    hot: true,
+    inline: !isProd,
+    hot: !isProd,
   }
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,8 +7,6 @@ const isProd = nodeEnv === 'production';
 const sourcePath = path.join(__dirname, './client');
 const staticsPath = path.join(__dirname, './static');
 
-const babelPresets = [['es2015', { modules: false }], 'react'];
-
 const plugins = [
   new webpack.optimize.CommonsChunkPlugin({
     name: 'vendor',
@@ -49,7 +47,6 @@ if (isProd) {
   plugins.push(
     new webpack.HotModuleReplacementPlugin()
   );
-  babelPresets.push('react-hmre');
 }
 
 module.exports = {
@@ -85,13 +82,7 @@ module.exports = {
         test: /\.(js|jsx)$/,
         exclude: /node_modules/,
         use: [
-          { loader: 'babel-loader',
-            query: {
-              babelrc: false,
-              presets: babelPresets,
-              plugins: ['transform-class-properties'],
-            }
-          }
+          'babel-loader'
         ],
       },
     ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ const plugins = [
   new webpack.DefinePlugin({
     'process.env': { NODE_ENV: JSON.stringify(nodeEnv) }
   }),
+  new webpack.HotModuleReplacementPlugin(),
   new webpack.NamedModulesPlugin(),
 ];
 
@@ -97,5 +98,7 @@ module.exports = {
     port: 3000,
     compress: isProd,
     stats: { colors: true },
+    inline: true,
+    hot: true,
   }
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,8 @@ const plugins = [
   }),
   new webpack.DefinePlugin({
     'process.env': { NODE_ENV: JSON.stringify(nodeEnv) }
-  })
+  }),
+  new webpack.NamedModulesPlugin(),
 ];
 
 if (isProd) {


### PR DESCRIPTION
I thought it might be nice to have a demonstration of hot reloading with Webpack as it's such a cool feature. This commit puts basic hot reloading support in place via the npm start call and the babel config has been configured to handle hot reloading of the React components.
The NamedModulesPlugin has been added to provide the full path and name of any hot reloaded modules in the console.