### PR TITLE
Exp/lintci

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,3 +31,4 @@ rules:
   import/no-unresolved: 0
   import/extensions: 0
   react/jsx-filename-extension: 0
+  react/prefer-stateless-function: 0

--- a/circle.yml
+++ b/circle.yml
@@ -14,4 +14,5 @@ dependencies:
 
 test:
   pre:
+    - npm run lint
     - npm run build

--- a/client/containers/App/index.js
+++ b/client/containers/App/index.js
@@ -1,8 +1,8 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import './style.css';
 
 export default class App extends Component {
   render() {
-    return <div></div>
+    return <div />;
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "babel-preset-react-hmre": "1.1.1",
     "cross-env": "3.1.4",
     "css-loader": "0.14.5",
-    "eslint": "3.14.0",
+    "eslint": "^3.16.1",
     "eslint-config-airbnb": "14.0.0",
     "eslint-plugin-import": "2.2.0",
     "eslint-plugin-jsx-a11y": "3.0.2",


### PR DESCRIPTION
Upgrades eslint dependency to avoid error on eslint-config-airbnb-base when running linter.