### PR TITLE
[finish #140926567] column overflow fix

### DIFF
--- a/client/components/BudgetGrid/style.scss
+++ b/client/components/BudgetGrid/style.scss
@@ -22,6 +22,7 @@
   th, td {
     padding: 8px;
     text-align: left;
+    overflow: hidden;
 
     &:first-child {
       padding-left: 2em;

--- a/client/containers/Budget/index.js
+++ b/client/containers/Budget/index.js
@@ -26,7 +26,6 @@ class Budget extends Component {
 
     return (
       <div>
-        <h1>Budget</h1>
         <BudgetGrid data={data} />
       </div>
     );


### PR DESCRIPTION
Columns should not overflow.

Before:
![](https://www.dropbox.com/s/mbci35vpfee55ni/Screenshot%202017-03-09%2012.09.58.png?dl=1)

After:
![](https://www.dropbox.com/s/co6d5zp0qo67jxf/Screenshot%202017-03-09%2012.09.33.png?dl=1)

Also removed Budgeting title, not needed as per the mocks