### PR TITLE
Add top level error handler

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,6 +26,7 @@ Feel free to use it as a reference app or a starter kit.
 - [x] CSS modules
 - [x] Snapshot testing with Jest
 - [x] Performance budgets in Webpack 3
+- [x] React 16 Error Boundaries
 
 ## Performance
 ![Budgeting App Performance](https://cloud.githubusercontent.com/assets/733074/25339194/1af94448-2902-11e7-8982-c1a9b647fac0.png)

--- a/app/components/AppError/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/AppError/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<div
+  className="errorScreen"
+>
+  <div
+    className="errorContainer"
+  >
+    <h1
+      className="errorTitle"
+    >
+      Sorry, something went wrong.
+    </h1>
+    <p>
+      We're working on it and we'll get it fixed as soon as we can.
+    </p>
+  </div>
+</div>
+`;

--- a/app/components/AppError/__tests__/index-test.js
+++ b/app/components/AppError/__tests__/index-test.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import AppError from '../';
+
+it('renders correctly', () => {
+  const tree = renderer.create(<AppError />).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/components/AppError/index.js
+++ b/app/components/AppError/index.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import styles from './style.scss';
+
+const AppError = () =>
+  <div className={styles.errorScreen}>
+    <div className={styles.errorContainer}>
+      <h1 className={styles.errorTitle}>{`Sorry, something went wrong.`}</h1>
+      <p>{`We're working on it and we'll get it fixed as soon as we can.`}</p>
+    </div>
+  </div>;
+
+export default AppError;

--- a/app/components/AppError/style.scss
+++ b/app/components/AppError/style.scss
@@ -1,0 +1,18 @@
+.errorScreen {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+}
+
+.errorContainer {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid lightgrey;
+  padding: 15px 30px;
+  border-radius: 13px;
+
+  .errorTitle {
+    font-size: 24px;
+  }
+}

--- a/app/components/ErrorBoundary/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/ErrorBoundary/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders a fallback component when the children component fails 1`] = `
+<div>
+  fallback
+</div>
+`;
+
+exports[`renders a working component 1`] = `
+<div>
+  working
+</div>
+`;

--- a/app/components/ErrorBoundary/__tests__/index-test.js
+++ b/app/components/ErrorBoundary/__tests__/index-test.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import ErrorBoundary from '../';
+
+const FailingComponent = () => {
+  throw new Error('I crashed');
+};
+
+const WorkingComponent = () => <div>working</div>;
+
+const FallbackComponent = () => <div>fallback</div>;
+
+beforeAll(() => {
+  // A console.error is expected here, saying that ErrorBoundary will handle an error.
+  // We mock this to see a clean output in the test runs.
+  console.error = jest.fn();
+});
+
+it('renders a working component', () => {
+  const tree = renderer
+    .create(
+      <ErrorBoundary fallbackComponent={FallbackComponent}>
+        <WorkingComponent />
+      </ErrorBoundary>
+    )
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('renders a fallback component when the children component fails', () => {
+  const tree = renderer
+    .create(
+      <ErrorBoundary fallbackComponent={FallbackComponent}>
+        <FailingComponent />
+      </ErrorBoundary>
+    )
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('calls an error handler when the children component fails', () => {
+  const handleError = jest.fn();
+
+  renderer.create(
+    <ErrorBoundary fallbackComponent={FallbackComponent} onError={handleError}>
+      <FailingComponent />
+    </ErrorBoundary>
+  );
+
+  expect(handleError).toHaveBeenCalled();
+});

--- a/app/components/ErrorBoundary/index.js
+++ b/app/components/ErrorBoundary/index.js
@@ -1,0 +1,47 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+class ErrorBoundary extends Component {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    fallbackComponent: PropTypes.func.isRequired,
+    onError: PropTypes.func,
+  };
+
+  static defaultProps = {
+    onError: null,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = { error: null, info: null };
+  }
+
+  componentDidCatch(error, info) {
+    // Catch errors in any components below and re-render with error message
+    this.setState({
+      error: error,
+      info: info,
+    });
+
+    // A callback can be used to log error messages
+    if (this.props.onError) {
+      this.props.onError(error, info);
+    }
+  }
+
+  render() {
+    const { fallbackComponent } = this.props;
+    const { error, info } = this.state;
+
+    if (error) {
+      // Render error component
+      return React.createElement(fallbackComponent, { error, info });
+    }
+
+    // Normally, just render children
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -1,20 +1,24 @@
 import React from 'react';
 import { Switch, Route, Redirect } from 'react-router-dom';
 
+import ErrorBoundary from 'components/ErrorBoundary';
+import AppError from 'components/AppError';
 import Header from 'components/Header';
 import Budget from 'routes/Budget';
 import Reports from 'routes/Reports';
 import './style.scss';
 
 const App = () =>
-  <main>
-    <Header />
+  <ErrorBoundary fallbackComponent={AppError}>
+    <main>
+      <Header />
 
-    <Switch>
-      <Route path="/budget" component={Budget} />
-      <Route path="/reports" component={Reports} />
-      <Redirect to="/budget" />
-    </Switch>
-  </main>;
+      <Switch>
+        <Route path="/budget" component={Budget} />
+        <Route path="/reports" component={Reports} />
+        <Redirect to="/budget" />
+      </Switch>
+    </main>
+  </ErrorBoundary>;
 
 export default App;


### PR DESCRIPTION
`AppError` is rendered at the top level if an uncaught error occurs during rendering, in lifecycle methods, and in constructors of any component in the whole react tree.

This is recommended to handle errors gracefully in React 16 because now the whole component tree will be unmounted if an uncaught error happens.

This is implemented as a reusable `ErrorBoundary` component, this way it can be used in a more granular way to handle errors in different parts of the app while the rest remain interactive.