### PR TITLE
Fix console errors in jest test run.

### DIFF
--- a/app/components/Legend/__tests__/LegendItem-test.js
+++ b/app/components/Legend/__tests__/LegendItem-test.js
@@ -3,6 +3,8 @@ import renderer from 'react-test-renderer';
 import LegendItem from '../LegendItem';
 
 it('renders correctly', () => {
-  const tree = renderer.create(<LegendItem color="test" value="test" label="test" />).toJSON();
+  const tree = renderer.create(<LegendItem color="test" value={3} label="test" />).toJSON();
   expect(tree).toMatchSnapshot();
+
+  window.requestAnimationFrame(() => 'wow');
 });

--- a/app/components/Legend/__tests__/__snapshots__/LegendItem-test.js.snap
+++ b/app/components/Legend/__tests__/__snapshots__/LegendItem-test.js.snap
@@ -15,7 +15,7 @@ exports[`renders correctly 1`] = `
     className="value"
   >
      
-    NaN
+    $3.00
      
   </span>
 </li>

--- a/app/components/Legend/__tests__/index-test.js
+++ b/app/components/Legend/__tests__/index-test.js
@@ -6,8 +6,10 @@ import Legend from '../';
 jest.mock('../LegendItem', () => 'div');
 
 it('renders correctly', () => {
+  const mockData = [{ key: 1 }, { key: 2 }];
+
   const tree = renderer
-    .create(<Legend data={['foo', 'bar']} dataValue="test" dataLabel="test" dataKey="test" color={() => {}} />)
+    .create(<Legend data={mockData} dataValue="test" dataLabel="test" dataKey="key" color={() => {}} />)
     .toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  setupFiles: ['<rootDir>/jest/requestAnimationFrame.js'],
   moduleFileExtensions: ['js', 'jsx'],
   moduleDirectories: ['node_modules', 'app'],
   moduleNameMapper: {

--- a/jest/requestAnimationFrame.js
+++ b/jest/requestAnimationFrame.js
@@ -1,0 +1,8 @@
+// Polyfill for rAF.
+//
+// This removes the React 16 warning "React depends on requestAnimationFrame"
+// when using Enzyme with React 16.
+// TODO: Remove this when Enzyme adds support for React 16 (v3)
+window.requestAnimationFrame = function(cb) {
+  return setTimeout(cb, 0);
+};


### PR DESCRIPTION
Add a `requestAnimationFrame` polyfill for Jest, this removes the React 16 warning "React depends on requestAnimationFrame" when rendering with enzyme in tests. It should be removed once Enzyme adds support for React 16.