### PR TITLE
Webpack 3.5 optimization for prod and dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage
 *.report.dom.html
 /dll
 .idea
+/.cache-loader

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint": "eslint ./app -f table",
     "lint:fix": "eslint ./app -f table --fix",
     "dll": "webpack --config webpack.dll.js",
-    "postinstall": "npm run dll"
+    "postinstall": "rimraf .cache-loader & npm run dll"
   },
   "devDependencies": {
     "add-asset-html-webpack-plugin": "^2.1.1",
@@ -69,6 +69,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
+    "cache-loader": "^1.0.3",
     "coveralls": "^2.13.1",
     "d3": "4.10.0",
     "prop-types": "^15.5.10",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "script-ext-html-webpack-plugin": "^1.8.5",
     "style-loader": "0.18.2",
     "sw-precache-webpack-plugin": "^0.11.4",
+    "thread-loader": "^1.1.1",
     "uglify-js": "3.0.27",
     "uglifyjs-webpack-plugin": "0.4.6",
     "webpack": "^3.5.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,9 +56,6 @@ module.exports = function(env) {
       'process.env': { NODE_ENV: JSON.stringify(nodeEnv) },
     }),
 
-    // create css bundle
-    new ExtractTextPlugin('style-[contenthash:8].css'),
-
     // create index.html
     new HtmlWebpackPlugin({
       template: htmlTemplate,
@@ -91,6 +88,9 @@ module.exports = function(env) {
 
   if (isProd) {
     plugins.push(
+      // create css bundle
+      new ExtractTextPlugin('style-[contenthash:8].css'),
+
       // minify remove some of the dead code
       new UglifyJSPlugin({
         compress: {
@@ -157,8 +157,10 @@ module.exports = function(env) {
     );
 
     cssLoader = [
+      // cache css output for faster rebuilds
       'cache-loader',
       {
+        // build css/sass in threads (faster)
         loader: 'thread-loader',
         options: {
           workerParallelJobs: 2,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -111,6 +111,7 @@ module.exports = function(env) {
     cssLoader = ExtractTextPlugin.extract({
       fallback: 'style-loader',
       use: [
+        'cache-loader',
         {
           loader: 'thread-loader',
           options: {
@@ -156,6 +157,7 @@ module.exports = function(env) {
     );
 
     cssLoader = [
+      'cache-loader',
       {
         loader: 'thread-loader',
         options: {

--- a/webpack.dll.js
+++ b/webpack.dll.js
@@ -4,10 +4,11 @@ const path = require('path');
 const outputPath = path.resolve('dll');
 
 module.exports = {
-  devtool: 'source-map',
+  devtool: 'cheap-source-map',
   entry: {
-    react: ['react', 'react-dom'],
-    reactContrib: [
+    libs: [
+      'react',
+      'react-dom',
       'react-router',
       'redux',
       'react-redux',
@@ -15,8 +16,8 @@ module.exports = {
       'react-router-dom',
       'redux-thunk',
       'reselect',
+      'd3',
     ],
-    d3: ['d3'],
   },
 
   output: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1362,6 +1362,14 @@ bytes@2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.5.0.tgz#4c9423ea2d252c270c41b2bdefeff9bb6b62c06a"
 
+cache-loader@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/cache-loader/-/cache-loader-1.0.3.tgz#7717963ec082db068b17a1412deaaa72d21c4e30"
+  dependencies:
+    async "^2.3.0"
+    loader-utils "^1.1.0"
+    mkdirp "^0.5.1"
+
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7768,6 +7768,14 @@ text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
+thread-loader@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/thread-loader/-/thread-loader-1.1.1.tgz#a351bd9d12978f42b82aab74f76e896eed0a2ba6"
+  dependencies:
+    async "^2.3.0"
+    loader-runner "^2.3.0"
+    loader-utils "^1.1.0"
+
 throat@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-3.2.0.tgz#50cb0670edbc40237b9e347d7e1f88e4620af836"


### PR DESCRIPTION
Build time went from ~15 sec to ~10 sec. Incremental builds in dev are also much faster. 

## Proposed Changes

* Single DLL instead of multiple
* Cheaper DLL sourcemaps
* Limit loaders to the app folder only
* Don't follow symlinks in resolvers
* Thread-loader for babel and sass
* Cache-loader for sass
* Faster sourcemap setup
* Fixed location of extracttextplugin so it's registered just in prod

## Checklist

* [x] Feature developed
* [x] Comments in code
