### PR TITLE
Make libs.dll.js load synchronously

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -80,6 +80,7 @@ module.exports = function(env) {
     // make sure script tags are async to avoid blocking html render
     new ScriptExtHtmlWebpackPlugin({
       defaultAttribute: 'async',
+      sync: /^libs.dll.*$/,
       preload: {
         test: /^0|^main|^style-.*$/,
         chunks: 'all',


### PR DESCRIPTION
Remove the `async` attribute from libs.dll.js. This fixes the intermittent issue in development caused when
`main.js` is executed before `libs.dll.js` loads.

Fixes https://github.com/ModusCreateOrg/budgeting-sample-app-webpack2/issues/104
