### PR TITLE
budget detail page

### DIFF
--- a/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
@@ -1,44 +1,52 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<tr>
-  <td>
-    <div
-      className="cellLabel"
-    >
-      Category
-    </div>
-    <div
-      className="cellContent"
-    >
-      Groceries
-    </div>
-  </td>
-  <td>
-    <div
-      className="cellLabel"
-    >
-      Description
-    </div>
-    <div
-      className="cellContent"
-    >
-      Trader Joe's food
-    </div>
-  </td>
-  <td
-    className="neg"
+<a
+  className="link"
+  href="/transaction/1"
+  onClick={[Function]}
+>
+  <tr
+    className="row"
   >
-    <div
-      className="cellLabel"
+    <td>
+      <div
+        className="cellLabel"
+      >
+        Category
+      </div>
+      <div
+        className="cellContent"
+      >
+        Groceries
+      </div>
+    </td>
+    <td>
+      <div
+        className="cellLabel"
+      >
+        Description
+      </div>
+      <div
+        className="cellContent"
+      >
+        Trader Joe's food
+      </div>
+    </td>
+    <td
+      className="neg"
     >
-      Amount
-    </div>
-    <div
-      className="cellContent"
-    >
-      -$423.34
-    </div>
-  </td>
-</tr>
+      <div
+        className="cellLabel"
+      >
+        Amount
+      </div>
+      <div
+        className="cellContent"
+      >
+        -$423.34
+      </div>
+    </td>
+  </tr>
+</a>
 `;

--- a/app/components/BudgetGridRow/__tests__/index-test.js
+++ b/app/components/BudgetGridRow/__tests__/index-test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import BudgetGridRow from 'components/BudgetGridRow';
+import { StaticRouter } from 'react-router';
 
 it('renders correctly', () => {
   const mockTransaction = {
@@ -15,6 +16,13 @@ it('renders correctly', () => {
     2: 'School',
   };
 
-  const tree = renderer.create(<BudgetGridRow transaction={mockTransaction} categories={mockCategories} />).toJSON();
+  const tree = renderer
+    .create(
+      <StaticRouter location="/" context={{}}>
+        <BudgetGridRow transaction={mockTransaction} categories={mockCategories} />
+      </StaticRouter>
+    )
+    .toJSON();
+
   expect(tree).toMatchSnapshot();
 });

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -1,10 +1,13 @@
 // @flow
 import * as React from 'react';
+import { Link } from 'react-router-dom';
+
 import formatAmount from 'utils/formatAmount';
 import type { Transaction } from 'modules/transactions';
 import type { Categories } from 'modules/categories';
 import styles from './style.scss';
 
+// budget frid type
 type BudgetGridRowProps = {
   transaction: Transaction,
   categories: Categories,
@@ -15,22 +18,25 @@ const BudgetGridRow = ({ transaction, categories }: BudgetGridRowProps) => {
   const amountCls = amount.isNegative ? styles.neg : styles.pos;
   const { id, categoryId, description } = transaction;
   const category = categories[categoryId];
+  const budgetUrl = `/transaction/${id}`;
 
   return (
-    <tr key={id}>
-      <td>
-        <div className={styles.cellLabel}>Category</div>
-        <div className={styles.cellContent}>{category}</div>
-      </td>
-      <td>
-        <div className={styles.cellLabel}>Description</div>
-        <div className={styles.cellContent}>{description}</div>
-      </td>
-      <td className={amountCls}>
-        <div className={styles.cellLabel}>Amount</div>
-        <div className={styles.cellContent}>{amount.text}</div>
-      </td>
-    </tr>
+    <Link className={styles.link} to={budgetUrl}>
+      <tr key={id} className={styles.row}>
+        <td>
+          <div className={styles.cellLabel}>Category</div>
+          <div className={styles.cellContent}>{category}</div>
+        </td>
+        <td>
+          <div className={styles.cellLabel}>Description</div>
+          <div className={styles.cellContent}>{description}</div>
+        </td>
+        <td className={amountCls}>
+          <div className={styles.cellLabel}>Amount</div>
+          <div className={styles.cellContent}>{amount.text}</div>
+        </td>
+      </tr>
+    </Link>
   );
 };
 

--- a/app/components/BudgetGridRow/style.scss
+++ b/app/components/BudgetGridRow/style.scss
@@ -1,5 +1,16 @@
 @import 'theme/variables';
 
+.row {
+  &:hover {
+    cursor: pointer;
+  }
+}
+
+.link {
+  color: inherit;
+  text-decoration: none;
+}
+
 .cellLabel {
   display: none;
 

--- a/app/components/Header/index.js
+++ b/app/components/Header/index.js
@@ -8,7 +8,7 @@ import styles from './style.scss';
 
 export default () => (
   <div className={styles.header}>
-    <NavLink to="/budget" label="Budget" styles={styles} />
+    <NavLink to="/budgets" label="Budget" styles={styles} />
     <NavLink to="/reports" label="Reports" styles={styles} />
     <GitHubButton className={styles.gitHubButton} type="Star" />
     <GitHubButton className={styles.gitHubButton} type="Fork" />

--- a/app/components/PieChart/__test__/__snapshots__/index-test.js.snap
+++ b/app/components/PieChart/__test__/__snapshots__/index-test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<div
+  className="pieChart"
+>
+  <div
+    height={316}
+    padding={8}
+    transform="translate(150,150)"
+    width={316}
+  />
+  <div
+    data={Array []}
+    dataKey="test"
+    dataLabel="test"
+    dataValue="value"
+  />
+</div>
+`;

--- a/app/components/PieChart/__test__/index-test.js
+++ b/app/components/PieChart/__test__/index-test.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import PieChart from '../';
+
+// mock nested components
+jest.mock('components/DonutChart/Path');
+jest.mock('components/Chart', () => 'div');
+
+it('renders correctly', () => {
+  const tree = renderer.create(<PieChart dataLabel="test" dataKey="test" data={[]} />).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/components/PieChart/index.js
+++ b/app/components/PieChart/index.js
@@ -1,39 +1,38 @@
 // @flow
-
 import * as React from 'react';
-import Legend from 'components/Legend';
+import { arc, pie } from 'd3';
+
 import Chart from 'components/Chart';
+import Path from 'components/DonutChart/Path';
+
 import type { TransactionSummary } from 'selectors/transactions';
-import { arc, pie, scaleOrdinal, schemeCategory20 } from 'd3';
-import { shuffle } from 'utils/array';
-import Path from './Path';
 import styles from './styles.scss';
 
-const randomScheme = shuffle(schemeCategory20);
-
-type DonutChartProps = {
+// pie chart types
+type PieChartProps = {
   data: TransactionSummary[],
   dataLabel: string,
   dataKey: string,
   dataValue: string,
-  color: Function,
   height: number,
   innerRatio: number,
 };
 
-class DonutChart extends React.Component<DonutChartProps> {
+// class piechart to export
+class PieChart extends React.Component<PieChartProps> {
   static defaultProps = {
-    color: scaleOrdinal(randomScheme),
     height: 300,
-    innerRatio: 150,
+    innerRatio: 300 / 2,
     dataValue: 'value',
   };
 
+  // this event update chart variables
   componentWillMount() {
     this.updateChartVariables();
   }
 
-  componentWillReceiveProps(nextProps: DonutChartProps) {
+  // this funct update new props
+  componentWillReceiveProps(nextProps: PieChartProps) {
     const { data, color, height } = nextProps;
 
     const old = this.props;
@@ -43,6 +42,7 @@ class DonutChart extends React.Component<DonutChartProps> {
     }
   }
 
+  // funct to calc inner radius and outer raduis
   getPathArc = () => {
     const { height, innerRatio } = this.props;
     return arc()
@@ -52,29 +52,28 @@ class DonutChart extends React.Component<DonutChartProps> {
 
   chart: any;
   pathArc: any;
-  colorFn: any;
   outerRadius: number;
   boxLength: number;
   chartPadding = 8;
 
+  // funct to update varibales by props
   updateChartVariables = () => {
-    const { data, dataValue, color, height } = this.props;
+    const { dataValue, height } = this.props;
 
     this.chart = pie()
       .value(d => d[dataValue])
       .sort(null);
     this.outerRadius = height / 2;
     this.pathArc = this.getPathArc();
-    this.colorFn = color.domain && color.domain([0, data.length]);
     this.boxLength = height + this.chartPadding * 2;
   };
 
   render() {
-    const { data, dataLabel, dataValue, dataKey } = this.props;
-    const { outerRadius, pathArc, colorFn, boxLength, chartPadding } = this;
+    const { data, dataKey } = this.props;
+    const { outerRadius, pathArc, boxLength, chartPadding } = this;
 
     return (
-      <div className={styles.donutChart}>
+      <div className={styles.pieChart}>
         <Chart
           width={boxLength}
           height={boxLength}
@@ -82,14 +81,12 @@ class DonutChart extends React.Component<DonutChartProps> {
           transform={`translate(${outerRadius},${outerRadius})`}
         >
           {this.chart(data).map((datum, index) => (
-            <Path data={datum} index={index} fill={colorFn(index)} arcFn={pathArc} key={datum.data[dataKey]} />
+            <Path data={datum} index={index} fill={datum.data.color} arcFn={pathArc} key={datum.data[dataKey]} />
           ))}
         </Chart>
-
-        <Legend color={colorFn} {...{ data, dataValue, dataLabel, dataKey }} />
       </div>
     );
   }
 }
 
-export default DonutChart;
+export default PieChart;

--- a/app/components/PieChart/styles.scss
+++ b/app/components/PieChart/styles.scss
@@ -1,0 +1,7 @@
+.pieChart {
+  display: flex;
+  height: 100%;  
+  justify-content: center;
+  align-content: flex-start;
+  flex-flow: wrap;  
+}

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -6,6 +6,7 @@ import ErrorBoundary from 'components/ErrorBoundary';
 import AppError from 'components/AppError';
 import Header from 'components/Header';
 import Budget from 'routes/Budget';
+import BudgetDetail from 'routes/BudgetDetail';
 import Reports from 'routes/Reports';
 import './style.scss';
 
@@ -16,6 +17,7 @@ const App = () => (
 
       <Switch>
         <Route path="/budget" component={Budget} />
+        <Route path="/transaction/:budgetId" component={BudgetDetail} />
         <Route path="/reports" component={Reports} />
         <Redirect to="/budget" />
       </Switch>

--- a/app/containers/BudgetDetail/__test__/__snapshots__/index-test.js.snap
+++ b/app/containers/BudgetDetail/__test__/__snapshots__/index-test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<div>
+  <div>
+    <h1>(<small>$100.00</small>)</h1>
+    <h4>Category:</h4>
+    <p>Misc</p>
+    <h4>Percentage:</h4>
+    <p>
+      <span className="positive">+50.00%</span>
+      of Inflow
+    </p>
+  </div>
+  <div className="chartContent"/>
+</div>
+`;

--- a/app/containers/BudgetDetail/__test__/index-test.js
+++ b/app/containers/BudgetDetail/__test__/index-test.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import BudgetDetail from '../';
+
+jest.mock('components/PieChart');
+
+it('renders correctly', () => {
+  const tree = renderer
+    .create(
+      <BudgetDetail.WrappedComponent
+        percentage={0.5}
+        inflowRemaining={200}
+        outflowRemaining={200}
+        transaction={{
+          id: 1,
+          value: 100,
+        }}
+        category="Misc"
+      />
+    )
+    .toJSON();
+
+  expect(tree).toMatchSnapshot();
+});

--- a/app/containers/BudgetDetail/index.js
+++ b/app/containers/BudgetDetail/index.js
@@ -1,0 +1,89 @@
+// @flow
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { PropTypes } from 'prop-types';
+
+import formatAmount from 'utils/formatAmount';
+import formatPercentage from 'utils/formatPercentage';
+import { getCategoryById } from 'selectors/categories';
+import type { TransactionSummary } from 'selectors/transactions';
+import { getPercentageInInflowOutflowByAmount } from 'selectors/transactions';
+import PieChart from 'components/PieChart';
+import styles from './style.scss';
+
+// Budget Detail props type
+type BudgetDetailProps = {
+  transaction: TransactionSummary,
+  percetage: number,
+  total: object,
+  category: string,
+};
+
+// class to export budgetdetail
+class BudgetDetail extends React.Component<BudgetDetailProps> {
+  // defined propTypes requireds & types
+  static propTypes = {
+    transaction: PropTypes.object.isRequired,
+    percentage: PropTypes.number.isRequired,
+    totals: PropTypes.object.isRequired,
+    category: PropTypes.string.isRequired,
+  };
+
+  // funct to defined data to piechart
+  getChartData() {
+    const { transaction, percentage } = this.props;
+    const { isNegative } = formatAmount(transaction.value);
+    const chartData = [
+      {
+        transaction: transaction.description,
+        transactionId: transaction.id,
+        value: Math.abs(percentage * 100),
+        color: isNegative ? '#EB2A2A' : '#189C2D',
+      },
+      { transaction: 'Total', transactionId: 'total', value: 100 - Math.abs(percentage * 100), color: '#D1C3C0' },
+    ];
+    return chartData;
+  }
+
+  render() {
+    const { transaction, category, percentage, totals } = this.props;
+    const { text, isNegative } = formatAmount(transaction.value);
+    const outflow = formatAmount(totals.outflow);
+    const inflow = formatAmount(totals.inflow);
+    const formattedPercentage = formatPercentage(percentage);
+    const colorPercentage = isNegative ? styles.negative : styles.positive;
+    const chart = this.getChartData();
+
+    return (
+      <section>
+        <div>
+          <h1>
+            {transaction.description} (<small className={colorPercentage}>{text}</small>)
+          </h1>
+          <h4>Category:</h4>
+          <p>{category}</p>
+          <h4>Detail:</h4>
+          <p>
+            Total {isNegative ? 'Outflow' : 'Inflow'}:
+            <span className={colorPercentage}> {isNegative ? `- ${outflow.text}` : inflow.text}</span>
+          </p>
+          <h4>Percentage:</h4>
+          <p>
+            <span className={colorPercentage}>{formattedPercentage}</span> of {isNegative ? 'Outflow' : 'Inflow'}
+          </p>
+        </div>
+        <div className="chartContent">
+          <PieChart data={chart || []} dataKey="transactionId" />
+        </div>
+      </section>
+    );
+  }
+}
+
+// map state to define data
+const mapStateToProps = (state, { transaction: { value, categoryId } }) => ({
+  percentage: getPercentageInInflowOutflowByAmount(value)(state),
+  category: getCategoryById(categoryId)(state),
+});
+
+export default connect(mapStateToProps)(BudgetDetail);

--- a/app/containers/BudgetDetail/style.scss
+++ b/app/containers/BudgetDetail/style.scss
@@ -1,0 +1,13 @@
+@import 'theme/variables';
+
+.chartContainer {
+  display: flex;
+}
+
+.negative {
+  color: $red;
+}
+
+.positive {
+  color: $green;
+}

--- a/app/containers/Transaction/index.js
+++ b/app/containers/Transaction/index.js
@@ -1,0 +1,55 @@
+// @flow
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { connect } from 'react-redux';
+import type { TransactionSummary } from 'selectors/transactions';
+
+import { getInflowBalance, getOutflowBalance, getTransactionById } from 'selectors/transactions';
+
+import { injectAsyncReducers } from 'store';
+import transactionReducer from 'modules/transactions';
+import categoryReducer from 'modules/categories';
+import BudgetDetail from 'containers/BudgetDetail';
+
+// inject reducers that might not have been originally there
+injectAsyncReducers({
+  transactions: transactionReducer,
+  categories: categoryReducer,
+});
+
+type TransactionProps = {
+  data: {
+    transaction: TransactionSummary,
+  },
+  totals: {
+    inflow: number,
+    outflow: number,
+  },
+};
+
+// Transaction class to export
+class Transaction extends React.Component<TransactionProps> {
+  render() {
+    const { data, totals } = this.props;
+
+    return (
+      <div>
+        <Link to="/budgets">← Back</Link>
+        {data.transaction ? <BudgetDetail transaction={data.transaction} totals={totals} /> : <p>Not found</p>}
+      </div>
+    );
+  }
+}
+
+// map state to define data transaction by id and total
+const mapStateToProps = (state, { budgetId }) => ({
+  data: {
+    transaction: getTransactionById(budgetId)(state),
+  },
+  totals: {
+    inflow: getInflowBalance(state),
+    outflow: Math.abs(getOutflowBalance(state)),
+  },
+});
+
+export default connect(mapStateToProps)(Transaction);

--- a/app/modules/rootReducer.js
+++ b/app/modules/rootReducer.js
@@ -7,8 +7,8 @@ import type { Transaction } from 'modules/transactions';
 // inject reducers.
 
 export type State = {
-  +categories?: Categories,
-  +transactions?: Transaction[],
+  categories?: Categories,
+  transactions?: Transaction[],
 };
 
 /**

--- a/app/routes/BudgetDetail/index.js
+++ b/app/routes/BudgetDetail/index.js
@@ -1,0 +1,14 @@
+// @flow
+import React, { Component } from 'react';
+import Chunk from 'components/Chunk';
+
+const loadBudgetDetailContainer = () => import('containers/Transaction' /* webpackChunkName: "budget" */);
+
+class BudgetDetail extends Component {
+  render() {
+    const { match } = this.props;
+    return <Chunk load={loadBudgetDetailContainer} budgetId={match.params.budgetId} />;
+  }
+}
+
+export default BudgetDetail;

--- a/app/selectors/__tests__/categories-test.js
+++ b/app/selectors/__tests__/categories-test.js
@@ -1,4 +1,4 @@
-import { getCategories, getDefaultCategoryId } from '../categories';
+import { getCategories, getDefaultCategoryId, getCategoryById } from '../categories';
 
 describe('getCategories', () => {
   it('should return all categories in the state', () => {
@@ -27,5 +27,17 @@ describe('getCategories', () => {
 describe('getDefaultCategoryId', () => {
   it('should return default category ID', () => {
     expect(getDefaultCategoryId()).toEqual('16');
+  });
+});
+
+describe('getCategoryById', () => {
+  it('should return catory with id', () => {
+    const state = {
+      categories: {
+        1: 'Groceries',
+      },
+    };
+
+    expect(getCategoryById(1)(state)).toEqual('Groceries');
   });
 });

--- a/app/selectors/__tests__/transactions-test.js
+++ b/app/selectors/__tests__/transactions-test.js
@@ -8,6 +8,8 @@ import {
   getFormattedOutflowBalance,
   getOutflowByCategoryName,
   getInflowByCategoryName,
+  getTransactionById,
+  getPercentageInInflowOutflowByAmount,
 } from '../transactions';
 
 // Mock 'selectors/categories' dependency
@@ -47,6 +49,14 @@ describe('getTransactions', () => {
     const expectedSelection = [];
 
     expect(getTransactions(state)).toEqual(expectedSelection);
+  });
+});
+
+describe('getTransactionById', () => {
+  it('returns transaction by id', () => {
+    const state = { transactions: [{ id: 1 }, { id: 2 }] };
+    const result = getTransactionById(1)(state);
+    expect(result.id).toEqual(1);
   });
 });
 
@@ -370,5 +380,19 @@ describe('getInflowByCategoryName', () => {
     expect(getInflowByCategoryName.recomputations()).toEqual(1);
     expect(getInflowByCategoryName(state3)).toEqual(expectedSelection2);
     expect(getInflowByCategoryName.recomputations()).toEqual(2);
+  });
+});
+
+describe('getPercentageInInflowOutflowByAmount', () => {
+  it('returns percentage of amount of inflow', () => {
+    const state = { transactions: [{ value: 1000 }] };
+    const result = getPercentageInInflowOutflowByAmount(200)(state);
+    expect(result).toEqual(0.2);
+  });
+
+  it('return percentage of amount of outflow', () => {
+    const state = { transactions: [{ value: -1000 }] };
+    const result = getPercentageInInflowOutflowByAmount(-200)(state);
+    expect(result).toEqual(-0.2);
   });
 });

--- a/app/selectors/categories.js
+++ b/app/selectors/categories.js
@@ -1,4 +1,5 @@
 // @flow
+import { createSelector } from 'reselect';
 import type { State } from 'modules/rootReducer';
 import type { Categories } from 'modules/categories';
 
@@ -7,3 +8,5 @@ const DEFAULT_CATEGORY_ID: string = '16';
 export const getCategories = (state: State): Categories => state.categories || {};
 
 export const getDefaultCategoryId = (): string => DEFAULT_CATEGORY_ID;
+
+export const getCategoryById = id => createSelector(getCategories, categories => categories[id]);

--- a/app/selectors/transactions.js
+++ b/app/selectors/transactions.js
@@ -78,3 +78,15 @@ export const getOutflowByCategoryName = createSelector(getOutflowByCategory, get
 export const getInflowByCategoryName = createSelector(getInflowByCategory, getCategories, (trans, cat) =>
   applyCategoryName(trans, cat)
 );
+
+export const getTransactionById = id =>
+  createSelector(getTransactions, transactions =>
+    transactions.find(transaction => String(transaction.id) === String(id))
+  );
+
+export const getPercentageInInflowOutflowByAmount = amount =>
+  createSelector(
+    getInflowBalance,
+    getOutflowBalance,
+    (inflow, outflow) => (amount > 0 ? amount / inflow : Math.abs(amount) / Math.abs(outflow) * -1)
+  );

--- a/app/utils/formatPercentage.js
+++ b/app/utils/formatPercentage.js
@@ -1,0 +1,8 @@
+export default function formatPercentage(fraction) {
+  const formatted = fraction.toLocaleString('en-us', {
+    style: 'percent',
+    minimumFractionDigits: 2,
+  });
+
+  return fraction > 0 ? `+${formatted}` : formatted;
+}


### PR DESCRIPTION
## Proposed Changes

### Feature 
As a user, I want to see percentage of total budget an item is contributing with, so I can better understand statistics of my inflow or outflow items

* Given that I have added at least one item to the budgeting grid When I click on that item 
Then I want to see a new page with a title corresponding to the item details 
* And route should be dynamic with item ID in it 
* And a subtitle under title should show percentage with red minus sign showing outflow, green plus sign for inflow 
* And a pie chart showing how much of the entire budget this item is contributing with should be on that page 
* And no other items from the budget should be on that pie chart 
* And there should be a back button to return back to the previous route 
* And the view should be mobile and desktop compatible 

## Screenshot

<img width="1280" alt="screen shot 2017-10-26 at 9 50 35 am" src="https://user-images.githubusercontent.com/1042826/32059976-2eae1cda-ba33-11e7-96b3-eea3acd26576.png">


## Checklist

* [x] Feature developed
* [ ] Created/updated unit tests
* [ ] Comments in code
* [ ] Documentation written

## Documentation 

###  New PieChart component
PieChart component data should look like array[] with object percentage and remaining percentage

```
{
     transaction: transaction.description,
     transactionId: transaction.id,
     value: porcentage,
     color: if is negative --> '#EB2A2A' : '#189C2D',
}
``` 

the new route detail of transaction
New /transactions/:budgetId route for transactions


### Folder Structure

The project should look like this new component, containers and router:

```
app/
    components/
       PieChart/
           __test__
           index.js
           styles.scss
    containers/
       BudgetDetail/
           __test__
           index.js
           styles.scss
        Transaction/
            index.js
    router
         BudgetDetail/
           index.js
```