### PR TITLE
Item Detail

### DIFF
--- a/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<tr>
+<tr
+  onClick={[Function]}
+>
   <td>
     <div
       className="cellLabel"

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -10,14 +10,18 @@ type BudgetGridRowProps = {
   categories: Categories,
 };
 
-const BudgetGridRow = ({ transaction, categories }: BudgetGridRowProps) => {
+const BudgetGridRow = ({ transaction, categories, changeUrl }: BudgetGridRowProps) => {
   const amount = formatAmount(transaction.value);
   const amountCls = amount.isNegative ? styles.neg : styles.pos;
   const { id, categoryId, description } = transaction;
   const category = categories[categoryId];
 
+  const handleClick = () => {
+    changeUrl(transaction);
+  }
+
   return (
-    <tr key={id}>
+    <tr key={id} onClick={handleClick}>
       <td>
         <div className={styles.cellLabel}>Category</div>
         <div className={styles.cellContent}>{category}</div>

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -8,7 +8,7 @@ import styles from './style.scss';
 type BudgetGridRowProps = {
   transaction: Transaction,
   categories: Categories,
-  changeUrl: Function
+  changeUrl: Function,
 };
 
 const BudgetGridRow = ({ transaction, categories, changeUrl }: BudgetGridRowProps) => {

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -8,6 +8,7 @@ import styles from './style.scss';
 type BudgetGridRowProps = {
   transaction: Transaction,
   categories: Categories,
+  changeUrl: Function
 };
 
 const BudgetGridRow = ({ transaction, categories, changeUrl }: BudgetGridRowProps) => {
@@ -18,7 +19,7 @@ const BudgetGridRow = ({ transaction, categories, changeUrl }: BudgetGridRowProp
 
   const handleClick = () => {
     changeUrl(transaction);
-  }
+  };
 
   return (
     <tr key={id} onClick={handleClick}>

--- a/app/components/PieChart/Path.js
+++ b/app/components/PieChart/Path.js
@@ -1,0 +1,44 @@
+// @flow
+import * as React from 'react';
+import { select, interpolate } from 'd3';
+
+type PathProps = {
+  data: Object,
+  fill: string,
+  arcFn: any,
+  animDuration: number,
+};
+
+class Path extends React.Component<PathProps> {
+  static defaultProps = {
+    animDuration: 1000,
+  };
+
+  componentDidMount() {
+    const { data, arcFn, animDuration } = this.props;
+    const path = select(this.pathRef);
+    const interpolateArc = interpolate(
+      { startAngle: 0, endAngle: 0 },
+      { startAngle: data.startAngle, endAngle: data.endAngle }
+    );
+
+    path
+      .transition()
+      .duration(animDuration)
+      .attrTween('d', () => t => arcFn(interpolateArc(t)));
+  }
+
+  pathRef: ?HTMLElement;
+
+  handleRefUpdate = (ref: ?HTMLElement) => {
+    this.pathRef = ref;
+  };
+
+  render() {
+    const { data, arcFn, fill } = this.props;
+
+    return <path ref={this.handleRefUpdate} fill={fill} d={arcFn(data)} />;
+  }
+}
+
+export default Path;

--- a/app/components/PieChart/__tests__/Path-test.js
+++ b/app/components/PieChart/__tests__/Path-test.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import Path from '../Path';
+
+it('renders correctly', () => {
+  const tree = renderer
+    .create(
+      <Path
+        data={{
+          startAngle: 3,
+          endAngle: 4,
+        }}
+        fill="fill"
+        arcFn={() => 'test'}
+        animDuration={3}
+      />
+    )
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/components/PieChart/__tests__/__snapshots__/Path-test.js.snap
+++ b/app/components/PieChart/__tests__/__snapshots__/Path-test.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<path
+  d="test"
+  fill="fill"
+/>
+`;

--- a/app/components/PieChart/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/PieChart/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<div
+  className="pieChart"
+>
+  <div
+    height={316}
+    padding={8}
+    transform="translate(150,150)"
+    width={316}
+  />
+  <div
+    color={[Function]}
+    data={Array []}
+    dataKey="test"
+    dataLabel="test"
+    dataValue="value"
+  />
+</div>
+`;

--- a/app/components/PieChart/__tests__/index-test.js
+++ b/app/components/PieChart/__tests__/index-test.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import DonutChart from '../';
+
+// mock nested components
+jest.mock('components/DonutChart/Path');
+jest.mock('components/Chart', () => 'div');
+jest.mock('components/Legend', () => 'div');
+
+it('renders correctly', () => {
+  const tree = renderer.create(<DonutChart dataLabel="test" dataKey="test" data={[]} />).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/components/PieChart/index.js
+++ b/app/components/PieChart/index.js
@@ -1,0 +1,95 @@
+// @flow
+
+import * as React from 'react';
+import Legend from 'components/Legend';
+import Chart from 'components/Chart';
+import type { TransactionSummary } from 'selectors/transactions';
+import { arc, pie, scaleOrdinal, schemeCategory20 } from 'd3';
+import { shuffle } from 'utils/array';
+import Path from './Path';
+import styles from './styles.scss';
+
+const randomScheme = shuffle(schemeCategory20);
+
+type PieChartProps = {
+  data: TransactionSummary[],
+  dataLabel: string,
+  dataKey: string,
+  dataValue: string,
+  color: Function,
+  height: number,
+  innerRatio: number,
+};
+
+class PieChart extends React.Component<PieChartProps> {
+  static defaultProps = {
+    color: scaleOrdinal(randomScheme),
+    height: 300,
+    innerRatio: 4,
+    dataValue: 'value',
+  };
+
+  componentWillMount() {
+    this.updateChartVariables();
+  }
+
+  componentWillReceiveProps(nextProps: PieChartProps) {
+    const { data, color, height } = nextProps;
+
+    const old = this.props;
+
+    if (old.data !== data || old.color !== color || old.height !== height) {
+      this.updateChartVariables();
+    }
+  }
+
+  getPathArc = () => {
+    const { height, innerRatio } = this.props;
+    return arc()
+      .innerRadius(height / innerRatio)
+      .outerRadius(height / 2);
+  };
+
+  chart: any;
+  pathArc: any;
+  colorFn: any;
+  outerRadius: number;
+  boxLength: number;
+  chartPadding = 8;
+
+  updateChartVariables = () => {
+    const { data, dataValue, color, height } = this.props;
+
+    this.chart = pie()
+      .value(d => d[dataValue])
+      .sort(null);
+    this.outerRadius = height / 2;
+    this.pathArc = this.getPathArc();
+    this.colorFn = color.domain && color.domain([0, data.length]);
+    this.boxLength = height + this.chartPadding * 2;
+  };
+
+  render() {
+    const { data, dataLabel, dataValue, dataKey } = this.props;
+    const { outerRadius, pathArc, colorFn, boxLength, chartPadding } = this;
+
+    return (
+      <div className={styles.pieChart}>
+        <Chart
+          width={boxLength}
+          height={boxLength}
+          padding={chartPadding}
+          transform={`translate(${outerRadius},${outerRadius})`}
+        >
+          {this.chart(data).map((datum, index) => (
+            <Path data={datum} index={index} fill={colorFn(index)} arcFn={pathArc} key={datum.data[dataKey]} />
+          ))}
+        </Chart>
+
+        <Legend color={colorFn} {...{ data, dataValue, dataLabel, dataKey }} />
+      </div>
+    );
+  }
+}
+
+export default PieChart;

--- a/app/components/PieChart/styles.scss
+++ b/app/components/PieChart/styles.scss
@@ -1,0 +1,7 @@
+.pieChart {
+  display: flex;
+  height: 100%;  
+  justify-content: center;
+  align-content: flex-start;
+  flex-flow: wrap;  
+}

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -6,6 +6,7 @@ import ErrorBoundary from 'components/ErrorBoundary';
 import AppError from 'components/AppError';
 import Header from 'components/Header';
 import Budget from 'routes/Budget';
+import BudgetDetail from 'routes/BudgetDetail';
 import Reports from 'routes/Reports';
 import './style.scss';
 
@@ -15,7 +16,8 @@ const App = () => (
       <Header />
 
       <Switch>
-        <Route path="/budget" component={Budget} />
+        <Route exact path="/budget" component={Budget} />
+        <Route path="/budget/:id" component={BudgetDetail} />
         <Route path="/reports" component={Reports} />
         <Redirect to="/budget" />
       </Switch>

--- a/app/containers/BudgetDetail/index.js
+++ b/app/containers/BudgetDetail/index.js
@@ -1,0 +1,88 @@
+// @flow
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import { withRouter } from 'react-router-dom';
+import { connect } from 'react-redux';
+import categoriesReducer from 'modules/categories';
+import transactionsReducer from 'modules/transactions';
+import { getCategories } from 'selectors/categories';
+import { getInflowBalance, getOutflowBalance, getTransactions, sortTransactions } from 'selectors/transactions';
+import styles from './style.scss';
+import { injectAsyncReducers } from 'store';
+import formatAmount from 'utils/formatAmount';
+
+import PieChart from 'components/DonutChart';
+
+// inject reducers that might not have been originally there
+injectAsyncReducers({
+  categories: categoriesReducer,
+  transactions: transactionsReducer
+});
+
+class BudgetDetail extends React.Component {
+  static propTypes = {
+    categories: PropTypes.object.isRequired,
+    transactions: PropTypes.array.isRequired
+  }
+
+  handleBackButton = () => {
+    this.props.history.goBack();
+  }
+
+  renderFound = (item) => {
+    const amount = formatAmount(item.value);
+    const amountCls = amount.isNegative ? styles.neg : styles.pos;
+    let total = Math.abs(getOutflowBalance(this.props));
+    if (item.value > 0) {
+      total = getInflowBalance(this.props);
+    }
+    const data = [
+      {
+        label: item.description,
+        key: item.id,
+        value: Math.abs(item.value),
+      }, {
+        label: 'Others',
+        key: 0,
+        value: total - Math.abs(item.value)
+      }
+    ];
+    const percentage = (Math.abs(item.value) / total) * 100;
+    return (
+      <section key={1}>
+        <h2>{item.description}</h2>
+        <p className={amountCls}>{amount.text} ({percentage.toFixed(2)}%)</p>
+        <PieChart data={data} dataLabel="label" dataKey="key" />;
+      </section>
+    )
+  }
+
+  renderNotFound = () => (
+    <div className={styles.errorScreen}>
+      <div className={styles.errorContainer}>
+        <h1 className={styles.errorTitle}>{`Sorry, something went wrong.`}</h1>
+        <p>{`Please check again whether the id is correct or not.`}</p>
+        <button className={styles.backButton} onClick={this.handleBackButton}>Back</button>
+      </div>
+    </div>
+  )
+
+  render() {
+    const { match, transactions } = this.props;
+    const item = transactions.find(item => item.id == match.params.id);
+    if (item) {
+      return [
+        <button key={0} className={styles.backButton} onClick={this.handleBackButton}>Back</button>,
+        this.renderFound(item)
+      ];
+    }
+    return this.renderNotFound(item);
+  }
+}
+
+const mapStateToProps = state => ({
+  categories: getCategories(state),
+  transactions: getTransactions(state)
+});
+
+export default withRouter(connect(mapStateToProps)(BudgetDetail));

--- a/app/containers/BudgetDetail/index.js
+++ b/app/containers/BudgetDetail/index.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import categoriesReducer from 'modules/categories';
@@ -11,48 +10,52 @@ import styles from './style.scss';
 import { injectAsyncReducers } from 'store';
 import formatAmount from 'utils/formatAmount';
 
-import PieChart from 'components/DonutChart';
+import PieChart from 'components/PieChart';
 
 // inject reducers that might not have been originally there
 injectAsyncReducers({
   categories: categoriesReducer,
-  transactions: transactionsReducer
+  transactions: transactionsReducer,
 });
 
-class BudgetDetail extends React.Component {
-  static propTypes = {
-    categories: PropTypes.object.isRequired,
-    transactions: PropTypes.array.isRequired
-  }
+type BudgetDetailProps = {
+  categories: Object,
+  transactions: Object,
+  history: Object,
+  match: Object
+}
 
+class BudgetDetail extends React.Component<BudgetDetailProps> {
   handleBackButton = () => {
-    this.props.history.goBack();
-  }
+    const { history } = this.props;
+    history.goBack();
+  };
 
-  renderFound = (item) => {
+  renderFound = item => {
     const amount = formatAmount(item.value);
     const amountCls = amount.isNegative ? styles.neg : styles.pos;
-    let total = Math.abs(getOutflowBalance(this.props));
-    if (item.value > 0) {
-      total = getInflowBalance(this.props);
-    }
+    let total = Math.abs(getInflowBalance(this.props));
     const data = [
       {
-        label: item.description,
-        key: item.id,
+        category: item.description,
+        categoryId: item.id,
         value: Math.abs(item.value),
-      }, {
-        label: 'Others',
-        key: 0,
-        value: total - Math.abs(item.value)
+      },
+      {
+        category: 'Remaining budget',
+        categoryId: '0',
+        value: total - Math.abs(item.value),
       }
     ];
-    const percentage = (Math.abs(item.value) / total) * 100;
+    const percentage = Math.abs(item.value) / total;
     return (
       <section key={1}>
         <h2>{item.description}</h2>
-        <p className={amountCls}>{amount.text} ({percentage.toFixed(2)}%)</p>
-        <PieChart data={data} dataLabel="label" dataKey="key" />;
+        <p className={amountCls}>
+          {!amount.isNegative && <span>+</span>}
+          {amount.text} ({percentage.toFixed(2)}%)
+        </p>
+        <PieChart data={data} dataLabel="category" dataKey="categoryId" />;
       </section>
     )
   }
@@ -76,7 +79,7 @@ class BudgetDetail extends React.Component {
         this.renderFound(item)
       ];
     }
-    return this.renderNotFound(item);
+    return this.renderNotFound();
   }
 }
 

--- a/app/containers/BudgetDetail/index.js
+++ b/app/containers/BudgetDetail/index.js
@@ -5,12 +5,11 @@ import { connect } from 'react-redux';
 import categoriesReducer from 'modules/categories';
 import transactionsReducer from 'modules/transactions';
 import { getCategories } from 'selectors/categories';
-import { getInflowBalance, getOutflowBalance, getTransactions, sortTransactions } from 'selectors/transactions';
-import styles from './style.scss';
+import { getInflowBalance, getTransactions } from 'selectors/transactions';
 import { injectAsyncReducers } from 'store';
 import formatAmount from 'utils/formatAmount';
-
 import PieChart from 'components/PieChart';
+import styles from './style.scss';
 
 // inject reducers that might not have been originally there
 injectAsyncReducers({
@@ -22,8 +21,8 @@ type BudgetDetailProps = {
   categories: Object,
   transactions: Object,
   history: Object,
-  match: Object
-}
+  match: Object,
+};
 
 class BudgetDetail extends React.Component<BudgetDetailProps> {
   handleBackButton = () => {
@@ -34,7 +33,7 @@ class BudgetDetail extends React.Component<BudgetDetailProps> {
   renderFound = item => {
     const amount = formatAmount(item.value);
     const amountCls = amount.isNegative ? styles.neg : styles.pos;
-    let total = Math.abs(getInflowBalance(this.props));
+    const total = Math.abs(getInflowBalance(this.props));
     const data = [
       {
         category: item.description,
@@ -45,9 +44,9 @@ class BudgetDetail extends React.Component<BudgetDetailProps> {
         category: 'Remaining budget',
         categoryId: '0',
         value: total - Math.abs(item.value),
-      }
+      },
     ];
-    const percentage = Math.abs(item.value) / total;
+    const percentage = 100 * Math.abs(item.value) / total;
     return (
       <section key={1}>
         <h2>{item.description}</h2>
@@ -57,26 +56,30 @@ class BudgetDetail extends React.Component<BudgetDetailProps> {
         </p>
         <PieChart data={data} dataLabel="category" dataKey="categoryId" />;
       </section>
-    )
-  }
+    );
+  };
 
   renderNotFound = () => (
     <div className={styles.errorScreen}>
       <div className={styles.errorContainer}>
         <h1 className={styles.errorTitle}>{`Sorry, something went wrong.`}</h1>
         <p>{`Please check again whether the id is correct or not.`}</p>
-        <button className={styles.backButton} onClick={this.handleBackButton}>Back</button>
+        <button className={styles.backButton} onClick={this.handleBackButton}>
+          Back
+        </button>
       </div>
     </div>
-  )
+  );
 
   render() {
     const { match, transactions } = this.props;
-    const item = transactions.find(item => item.id == match.params.id);
+    const item = transactions.find(i => i.id.toString() === match.params.id);
     if (item) {
       return [
-        <button key={0} className={styles.backButton} onClick={this.handleBackButton}>Back</button>,
-        this.renderFound(item)
+        <button key={0} className={styles.backButton} onClick={this.handleBackButton}>
+          Back
+        </button>,
+        this.renderFound(item),
       ];
     }
     return this.renderNotFound();
@@ -85,7 +88,7 @@ class BudgetDetail extends React.Component<BudgetDetailProps> {
 
 const mapStateToProps = state => ({
   categories: getCategories(state),
-  transactions: getTransactions(state)
+  transactions: getTransactions(state),
 });
 
 export default withRouter(connect(mapStateToProps)(BudgetDetail));

--- a/app/containers/BudgetDetail/style.scss
+++ b/app/containers/BudgetDetail/style.scss
@@ -1,0 +1,35 @@
+@import 'theme/variables';
+
+.backButton {
+  width: 50px;
+  background: #00d5af;
+  color: #fff;
+  border: none;
+}
+
+.errorScreen {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+}
+
+.errorContainer {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid lightgrey;
+  padding: 15px 30px;
+  border-radius: 13px;
+
+  .errorTitle {
+    font-size: 24px;
+  }
+}
+
+.neg {
+  color: $red;
+}
+
+.pos {
+  color: $green;
+}

--- a/app/containers/BudgetGrid/index.js
+++ b/app/containers/BudgetGrid/index.js
@@ -12,6 +12,7 @@ import styles from './style.scss';
 type BudgetGridProps = {
   transactions: Transaction[],
   categories: Object,
+  history: Object
 };
 
 export class BudgetGrid extends React.Component<BudgetGridProps> {
@@ -20,10 +21,10 @@ export class BudgetGrid extends React.Component<BudgetGridProps> {
     categories: {},
   };
 
-  changeUrl = (transaction) => {
-    const { id, categoryId, description } = transaction;
-    this.props.history.push(`/budget/${id}`);
-  }
+  changeUrl = (transaction: Transaction) => {
+    const { history } = this.props;
+    history.push(`/budget/${transaction.id}`);
+  };
 
   render() {
     const { transactions, categories } = this.props;
@@ -43,7 +44,8 @@ export class BudgetGrid extends React.Component<BudgetGridProps> {
               changeUrl={this.changeUrl}
               key={transaction.id}
               transaction={transaction}
-              categories={categories} />
+              categories={categories}
+            />
           ))}
         </tbody>
         <tfoot>

--- a/app/containers/BudgetGrid/index.js
+++ b/app/containers/BudgetGrid/index.js
@@ -12,7 +12,7 @@ import styles from './style.scss';
 type BudgetGridProps = {
   transactions: Transaction[],
   categories: Object,
-  history: Object
+  history: Object,
 };
 
 export class BudgetGrid extends React.Component<BudgetGridProps> {

--- a/app/containers/BudgetGrid/index.js
+++ b/app/containers/BudgetGrid/index.js
@@ -1,10 +1,11 @@
 // @flow
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
 import { getTransactions } from 'selectors/transactions';
 import { getCategories } from 'selectors/categories';
 import EntryFormRow from 'containers/EntryFormRow';
-import type { Transaction } from 'modules/transactions';
+import { Transaction } from 'modules/transactions';
 import BudgetGridRow from 'components/BudgetGridRow';
 import styles from './style.scss';
 
@@ -18,6 +19,11 @@ export class BudgetGrid extends React.Component<BudgetGridProps> {
     transactions: [],
     categories: {},
   };
+
+  changeUrl = (transaction) => {
+    const { id, categoryId, description } = transaction;
+    this.props.history.push(`/budget/${id}`);
+  }
 
   render() {
     const { transactions, categories } = this.props;
@@ -33,7 +39,11 @@ export class BudgetGrid extends React.Component<BudgetGridProps> {
         </thead>
         <tbody>
           {transactions.map((transaction: Transaction): React.Element<any> => (
-            <BudgetGridRow key={transaction.id} transaction={transaction} categories={categories} />
+            <BudgetGridRow
+              changeUrl={this.changeUrl}
+              key={transaction.id}
+              transaction={transaction}
+              categories={categories} />
           ))}
         </tbody>
         <tfoot>
@@ -49,4 +59,4 @@ const mapStateToProps = state => ({
   categories: getCategories(state),
 });
 
-export default connect(mapStateToProps)(BudgetGrid);
+export default withRouter(connect(mapStateToProps)(BudgetGrid));

--- a/app/containers/BudgetGrid/index.js
+++ b/app/containers/BudgetGrid/index.js
@@ -5,7 +5,7 @@ import { withRouter } from 'react-router-dom';
 import { getTransactions } from 'selectors/transactions';
 import { getCategories } from 'selectors/categories';
 import EntryFormRow from 'containers/EntryFormRow';
-import { Transaction } from 'modules/transactions';
+import type { Transaction } from 'modules/transactions';
 import BudgetGridRow from 'components/BudgetGridRow';
 import styles from './style.scss';
 

--- a/app/containers/Spending/index.js
+++ b/app/containers/Spending/index.js
@@ -14,7 +14,6 @@ type SpendingProps = {
 class Spending extends React.Component<SpendingProps> {
   render() {
     const { data } = this.props;
-
     return <DonutChart data={data} dataLabel="category" dataKey="categoryId" />;
   }
 }

--- a/app/routes/BudgetDetail/index.js
+++ b/app/routes/BudgetDetail/index.js
@@ -1,0 +1,13 @@
+// @flow
+import React, { Component } from 'react';
+import Chunk from 'components/Chunk';
+
+const loadBudgetDetailContainer = () => import('containers/BudgetDetail' /* webpackChunkName: "budget_detail" */);
+
+class BudgetDetail extends Component<{}> {
+  render() {
+    return <Chunk load={loadBudgetDetailContainer} />;
+  }
+}
+
+export default BudgetDetail;


### PR DESCRIPTION
**_This is part of Modus Create's coding test_**

## Feature 
As a user, I want to see percentage of total budget an item is contributing with, so I can better understand statistics of my inflow or outflow items 

## Acceptance Criteria 
Given that I have added at least one item to the budgeting grid 
When I click on that item 
Then I want to see a new page with a title corresponding to the item details 
And route should be dynamic with item ID in it 
And a subtitle under title should show percentage with red minus sign showing outflow, green plus sign for inflow 
And a pie chart showing how much of the entire budget this item is contributing with should be on that page 
And no other items from the budget should be on that pie chart 
And there should be a back button to return back to the previous route 
And the view should be mobile and desktop compatible 

## Checklist

* [x] Feature developed
* [x] Created/updated unit tests
* [ ] Comments in code
* [ ] Documentation written
