### PR TITLE
Add new budget item screen

### DIFF
--- a/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
@@ -15,16 +15,21 @@ exports[`renders correctly 1`] = `
     </div>
   </td>
   <td>
-    <div
-      className="cellLabel"
+    <a
+      href="budget/item/1"
+      onClick={[Function]}
     >
-      Description
-    </div>
-    <div
-      className="cellContent"
-    >
-      Trader Joe's food
-    </div>
+      <div
+        className="cellLabel"
+      >
+        Description
+      </div>
+      <div
+        className="cellContent"
+      >
+        Trader Joe's food
+      </div>
+    </a>
   </td>
   <td
     className="neg"

--- a/app/components/BudgetGridRow/__tests__/index-test.js
+++ b/app/components/BudgetGridRow/__tests__/index-test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import BudgetGridRow from 'components/BudgetGridRow';
+import { MemoryRouter } from 'react-router';
 
 it('renders correctly', () => {
   const mockTransaction = {
@@ -15,6 +16,12 @@ it('renders correctly', () => {
     2: 'School',
   };
 
-  const tree = renderer.create(<BudgetGridRow transaction={mockTransaction} categories={mockCategories} />).toJSON();
+  const tree = renderer
+    .create(
+      <MemoryRouter>
+        <BudgetGridRow transaction={mockTransaction} categories={mockCategories} />
+      </MemoryRouter>
+    )
+    .toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import formatAmount from 'utils/formatAmount';
 import type { Transaction } from 'modules/transactions';
 import type { Categories } from 'modules/categories';
@@ -23,8 +24,10 @@ const BudgetGridRow = ({ transaction, categories }: BudgetGridRowProps) => {
         <div className={styles.cellContent}>{category}</div>
       </td>
       <td>
-        <div className={styles.cellLabel}>Description</div>
-        <div className={styles.cellContent}>{description}</div>
+        <Link to={`budget/item/${id}`}>
+          <div className={styles.cellLabel}>Description</div>
+          <div className={styles.cellContent}>{description}</div>
+        </Link>
       </td>
       <td className={amountCls}>
         <div className={styles.cellLabel}>Amount</div>

--- a/app/containers/Budget/index.js
+++ b/app/containers/Budget/index.js
@@ -1,10 +1,13 @@
 // @flow
 import * as React from 'react';
+import { withRouter } from 'react-router';
+import { Route, Switch } from 'react-router-dom';
 import transactionReducer from 'modules/transactions';
 import categoryReducer from 'modules/categories';
 import { injectAsyncReducers } from 'store';
 import BudgetGrid from 'containers/BudgetGrid';
 import Balance from 'containers/Balance';
+import BudgetItem from './item';
 
 // inject reducers that might not have been originally there
 injectAsyncReducers({
@@ -12,11 +15,18 @@ injectAsyncReducers({
   categories: categoryReducer,
 });
 
-const BudgetContainer = () => (
+const Budget = () => (
   <section>
     <BudgetGrid />
     <Balance />
   </section>
 );
 
-export default BudgetContainer;
+const BudgetContainer = ({ match }) => (
+  <Switch>
+    <Route exact path="/budget" component={Budget} />
+    <Route path={`${match.url}/item/:id`} component={BudgetItem} />
+  </Switch>
+);
+
+export default withRouter(BudgetContainer);

--- a/app/containers/Budget/item.js
+++ b/app/containers/Budget/item.js
@@ -1,0 +1,53 @@
+/* 
+* @flow
+*/
+import * as React from 'react';
+import { withRouter } from 'react-router';
+import { compose, type Dispatch } from 'redux';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { getBudgetItem, getFlowAsTransaction } from 'selectors/transactions';
+import DonutChart from 'components/DonutChart';
+
+import type { Transaction as TransactionT } from 'modules/transactions';
+import style from './style.scss';
+
+type PropsT = {
+  item: TransactionT,
+  flow: TransactionT,
+};
+
+const BudgetItem = ({ item, flow }: PropsT): React.Node => {
+  const { description, value } = item;
+  const positiveFlow: boolean = value > 0;
+  const absValue = Math.abs(value);
+  const percentage = absValue * 100 / (flow.value + absValue);
+  const className = positiveFlow ? style.positive : style.negative;
+  const data = [
+    {
+      ...item,
+      value: absValue,
+    },
+    flow,
+  ];
+  return (
+    <div>
+      <Link to="/budget">
+        <button>Back</button>
+      </Link>
+      <h2>{description}</h2>
+      <h4>
+        <span className={className}>{positiveFlow ? '+' : '-'}</span>
+        <span className={className}>{`${percentage.toFixed(3)}%`}</span>
+      </h4>
+      <DonutChart data={data} dataLabel="description" dataKey="description" dataValue="value" />
+    </div>
+  );
+};
+
+const mapStateToProps = (state, ownProps) => ({
+  item: getBudgetItem(state, ownProps),
+  flow: getFlowAsTransaction(state, ownProps),
+});
+
+export default compose(withRouter, connect(mapStateToProps))(BudgetItem);

--- a/app/containers/Budget/item.js
+++ b/app/containers/Budget/item.js
@@ -3,7 +3,7 @@
 */
 import * as React from 'react';
 import { withRouter } from 'react-router';
-import { compose, type Dispatch } from 'redux';
+import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { getBudgetItem, getFlowAsTransaction } from 'selectors/transactions';

--- a/app/containers/Budget/style.scss
+++ b/app/containers/Budget/style.scss
@@ -1,0 +1,8 @@
+@import 'theme/variables';
+.positive {
+  color: $green;
+}
+
+.negative {
+  color: $red;
+}

--- a/app/containers/BudgetGrid/index.js
+++ b/app/containers/BudgetGrid/index.js
@@ -21,7 +21,7 @@ export class BudgetGrid extends React.Component<BudgetGridProps> {
 
   render() {
     const { transactions, categories } = this.props;
-
+    console.log(transactions);
     return (
       <table className={styles.budgetGrid}>
         <thead>

--- a/app/containers/BudgetGrid/index.js
+++ b/app/containers/BudgetGrid/index.js
@@ -21,7 +21,6 @@ export class BudgetGrid extends React.Component<BudgetGridProps> {
 
   render() {
     const { transactions, categories } = this.props;
-    console.log(transactions);
     return (
       <table className={styles.budgetGrid}>
         <thead>

--- a/app/routes/Budget/index.js
+++ b/app/routes/Budget/index.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import Chunk from 'components/Chunk';
+import BudgetItem from './item';
 
 const loadBudgetContainer = () => import('containers/Budget' /* webpackChunkName: "budget" */);
 
@@ -9,5 +10,7 @@ class Budget extends Component<{}> {
     return <Chunk load={loadBudgetContainer} />;
   }
 }
+
+export { BudgetItem };
 
 export default Budget;

--- a/app/routes/Budget/item.js
+++ b/app/routes/Budget/item.js
@@ -1,0 +1,13 @@
+// @flow
+import React, { Component } from 'react';
+import Chunk from 'components/Chunk';
+
+const loadBudgetItemContainer = () => import('containers/Budget/item' /* webpackChunkName: "budget" */);
+
+class BudgetItem extends Component<{}> {
+  render() {
+    return <Chunk load={loadBudgetItemContainer} />;
+  }
+}
+
+export default BudgetItem;

--- a/app/selectors/__tests__/transactions-test.js
+++ b/app/selectors/__tests__/transactions-test.js
@@ -8,6 +8,8 @@ import {
   getFormattedOutflowBalance,
   getOutflowByCategoryName,
   getInflowByCategoryName,
+  getBudgetItem,
+  getFlowAsTransaction,
 } from '../transactions';
 
 // Mock 'selectors/categories' dependency
@@ -370,5 +372,59 @@ describe('getInflowByCategoryName', () => {
     expect(getInflowByCategoryName.recomputations()).toEqual(1);
     expect(getInflowByCategoryName(state3)).toEqual(expectedSelection2);
     expect(getInflowByCategoryName.recomputations()).toEqual(2);
+  });
+});
+
+describe('getBudgetItem', () => {
+  it('should return the budget item by id', () => {
+    const itemToMatch = {
+      id: 1,
+      value: 130,
+    };
+
+    const state = {
+      transactions: [
+        itemToMatch,
+        {
+          id: 2,
+          value: 30,
+        },
+        {
+          id: 3,
+          value: 30,
+        },
+      ],
+    };
+    expect(getBudgetItem(state, { match: { params: { id: 1 } } })).toEqual(itemToMatch);
+  });
+
+  it('should return no item when given id is not a valid id', () => {
+    const state = {
+      transactions: [
+        {
+          id: 2,
+          value: 40,
+        },
+      ],
+    };
+    expect(getBudgetItem(state, { match: { params: { id: '1' } } })).toBeUndefined();
+  });
+});
+
+describe('getFlowAsTransaction', () => {
+  it('should return an amount based on the item value sign', () => {
+    const state = {
+      transactions: [{ id: 1, value: -10 }, { id: 2, value: -20 }, { id: 3, value: 30 }, { id: 4, value: 90 }],
+    };
+
+    expect(getFlowAsTransaction(state, { match: { params: { id: '1' } } })).toEqual({
+      description: 'Outflow Balance',
+      value: 20,
+    });
+
+    expect(getFlowAsTransaction(state, { match: { params: { id: '3' } } })).toEqual({
+      description: 'Inflow Balance',
+      value: 90,
+    });
   });
 });

--- a/app/selectors/transactions.js
+++ b/app/selectors/transactions.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { createSelector } from 'reselect';
+import type { Match } from 'react-router';
 import formatAmount from 'utils/formatAmount';
 import type { State } from 'modules/rootReducer';
 import type { Transaction } from 'modules/transactions';
@@ -77,4 +78,15 @@ export const getOutflowByCategoryName = createSelector(getOutflowByCategory, get
 
 export const getInflowByCategoryName = createSelector(getInflowByCategory, getCategories, (trans, cat) =>
   applyCategoryName(trans, cat)
+);
+
+export const getBudgetItem = (state: State, props: { match: Match }): ?Transaction =>
+  getTransactions(state).find(t => t.id === parseInt(props.match.params.id, 10));
+
+export const getRemainingFlowAsTransaction = createSelector(
+  [getBudgetItem, getInflowBalance, getOutflowBalance],
+  (transaction, inflowBalance, outflowBalance) => ({
+    description: `Remaining ${transaction.value > 0 ? 'Inflow' : 'Outflow'} Balance`,
+    value: Math.abs(transaction.value > 0 ? inflowBalance : outflowBalance) - Math.abs(transaction.value),
+  })
 );

--- a/app/selectors/transactions.js
+++ b/app/selectors/transactions.js
@@ -86,7 +86,6 @@ export const getBudgetItem = (state: State, props: { match: Match }): ?Transacti
 export const getFlowAsTransaction = createSelector(
   [getBudgetItem, getInflowBalance, getOutflowBalance],
   (transaction, inflowBalance, outflowBalance) => {
-    console.log(transaction, inflowBalance, outflowBalance);
     const getDescription = () => {
       if (transaction) {
         return `${transaction.value > 0 ? 'Inflow' : 'Outflow'} Balance`;

--- a/app/selectors/transactions.js
+++ b/app/selectors/transactions.js
@@ -83,10 +83,27 @@ export const getInflowByCategoryName = createSelector(getInflowByCategory, getCa
 export const getBudgetItem = (state: State, props: { match: Match }): ?Transaction =>
   getTransactions(state).find(t => t.id === parseInt(props.match.params.id, 10));
 
-export const getRemainingFlowAsTransaction = createSelector(
+export const getFlowAsTransaction = createSelector(
   [getBudgetItem, getInflowBalance, getOutflowBalance],
-  (transaction, inflowBalance, outflowBalance) => ({
-    description: `Remaining ${transaction.value > 0 ? 'Inflow' : 'Outflow'} Balance`,
-    value: Math.abs(transaction.value > 0 ? inflowBalance : outflowBalance) - Math.abs(transaction.value),
-  })
+  (transaction, inflowBalance, outflowBalance) => {
+    console.log(transaction, inflowBalance, outflowBalance);
+    const getDescription = () => {
+      if (transaction) {
+        return `${transaction.value > 0 ? 'Inflow' : 'Outflow'} Balance`;
+      }
+      return '';
+    };
+
+    const getValue = () => {
+      if (transaction) {
+        return Math.abs(transaction.value > 0 ? inflowBalance : outflowBalance) - Math.abs(transaction.value);
+      }
+      return 0;
+    };
+
+    return {
+      description: getDescription(),
+      value: getValue(),
+    };
+  }
 );


### PR DESCRIPTION
## Proposed Changes

### Feature
As a user, I want to see percentage of total budget an item is contributing with, so I can better understand statistics of my inflow or outflow items

### Acceptance Criteria
Given that I have added at least one item to the budgeting grid
When I click on that item
- [x] Then I want to see a new page with a title corresponding to the item details
- [x] And route should be dynamic with item ID in it
- [x] And a subtitle under title should show percentage 
- [ ] with red minus sign showing outflow, green plus sign for inflow
- [x] And a pie chart showing how much of the entire budget this item is contributing with should be on that page
- [x] And no other items from the budget should be on that pie chart
- [x] And there should be a back button to return back to the previous route
- [ ] And the view should be mobile and desktop compatible

## Screenshot

...

## Checklist

* [x] Feature developed
* [ ] Created/updated unit tests
* [x] Comments in code
* [ ] Documentation written
