### PR TITLE
Feature: Added Individual Item Page

### DIFF
--- a/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<tr>
+<tr
+  onClick={[Function]}
+>
   <td>
     <div
       className="cellLabel"

--- a/app/components/BudgetGridRow/__tests__/index-test.js
+++ b/app/components/BudgetGridRow/__tests__/index-test.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import BudgetGridRow from 'components/BudgetGridRow';
+import Router from 'react-router-dom';
+import { StaticRouter } from 'react-router';
 
 it('renders correctly', () => {
   const mockTransaction = {
@@ -15,6 +17,14 @@ it('renders correctly', () => {
     2: 'School',
   };
 
-  const tree = renderer.create(<BudgetGridRow transaction={mockTransaction} categories={mockCategories} />).toJSON();
+  const context = {};
+
+  const component = renderer.create(
+    <StaticRouter location="someLocation" context={context}>
+      <BudgetGridRow transaction={mockTransaction} categories={mockCategories} />
+    </StaticRouter>
+  )
+
+  const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/app/components/BudgetGridRow/__tests__/index-test.js
+++ b/app/components/BudgetGridRow/__tests__/index-test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import BudgetGridRow from 'components/BudgetGridRow';
-import Router from 'react-router-dom';
 import { StaticRouter } from 'react-router';
 
 it('renders correctly', () => {
@@ -23,7 +22,7 @@ it('renders correctly', () => {
     <StaticRouter location="someLocation" context={context}>
       <BudgetGridRow transaction={mockTransaction} categories={mockCategories} />
     </StaticRouter>
-  )
+  );
 
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -4,34 +4,38 @@ import formatAmount from 'utils/formatAmount';
 import type { Transaction } from 'modules/transactions';
 import type { Categories } from 'modules/categories';
 import styles from './style.scss';
+import { withRouter, Redirect } from 'react-router-dom';
 
 type BudgetGridRowProps = {
   transaction: Transaction,
   categories: Categories,
 };
 
-const BudgetGridRow = ({ transaction, categories }: BudgetGridRowProps) => {
-  const amount = formatAmount(transaction.value);
-  const amountCls = amount.isNegative ? styles.neg : styles.pos;
-  const { id, categoryId, description } = transaction;
-  const category = categories[categoryId];
+export class BudgetGridRow extends React.Component<BudgetGridRowProps> {
+  render() {
+    const { transaction, categories, history } = this.props;
+    const amount = formatAmount(transaction.value);
+    const amountCls = amount.isNegative ? styles.neg : styles.pos;
+    const { id, categoryId, description } = transaction;
+    const category = categories[categoryId];
 
-  return (
-    <tr key={id}>
-      <td>
-        <div className={styles.cellLabel}>Category</div>
-        <div className={styles.cellContent}>{category}</div>
-      </td>
-      <td>
-        <div className={styles.cellLabel}>Description</div>
-        <div className={styles.cellContent}>{description}</div>
-      </td>
-      <td className={amountCls}>
-        <div className={styles.cellLabel}>Amount</div>
-        <div className={styles.cellContent}>{amount.text}</div>
-      </td>
-    </tr>
-  );
+    return (
+      <tr key={id} onClick={() => history.push('/item/' + id )}>
+        <td>
+          <div className={styles.cellLabel}>Category</div>
+          <div className={styles.cellContent}>{category}</div>
+        </td>
+        <td>
+          <div className={styles.cellLabel}>Description</div>
+          <div className={styles.cellContent}>{description}</div>
+        </td>
+        <td className={amountCls}>
+          <div className={styles.cellLabel}>Amount</div>
+          <div className={styles.cellContent}>{amount.text}</div>
+        </td>
+      </tr>
+    );
+  }
 };
 
-export default BudgetGridRow;
+export default withRouter(BudgetGridRow);

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -1,10 +1,10 @@
 // @flow
 import * as React from 'react';
+import { withRouter } from 'react-router-dom';
 import formatAmount from 'utils/formatAmount';
 import type { Transaction } from 'modules/transactions';
 import type { Categories } from 'modules/categories';
 import styles from './style.scss';
-import { withRouter, Redirect } from 'react-router-dom';
 
 type BudgetGridRowProps = {
   transaction: Transaction,
@@ -20,7 +20,7 @@ export class BudgetGridRow extends React.Component<BudgetGridRowProps> {
     const category = categories[categoryId];
 
     return (
-      <tr key={id} onClick={() => history.push('/item/' + id )}>
+      <tr key={id} onClick={() => history.push(`/item/${id}`)}>
         <td>
           <div className={styles.cellLabel}>Category</div>
           <div className={styles.cellContent}>{category}</div>
@@ -36,6 +36,6 @@ export class BudgetGridRow extends React.Component<BudgetGridRowProps> {
       </tr>
     );
   }
-};
+}
 
 export default withRouter(BudgetGridRow);

--- a/app/components/BudgetGridRow/style.scss
+++ b/app/components/BudgetGridRow/style.scss
@@ -21,3 +21,8 @@
 .pos {
   color: $green;
 }
+
+tr:hover {
+   background: #EEE;
+   cursor: pointer;
+}

--- a/app/components/ItemPanel/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/ItemPanel/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<section>
+  <div />
+</section>
+`;

--- a/app/components/ItemPanel/__tests__/index-test.js
+++ b/app/components/ItemPanel/__tests__/index-test.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import ItemContainer from '../';
+
+// mock nested components
+jest.mock('containers/ItemPercentage', () => 'div');
+jest.mock('react-router-dom');
+
+it('renders correctly', () => {
+  const tree = renderer.create(<ItemContainer />).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/components/ItemPanel/index.js
+++ b/app/components/ItemPanel/index.js
@@ -1,10 +1,11 @@
 // @flow
 import * as React from 'react';
+import { connect } from 'react-redux';
 import transactionReducer from 'modules/transactions';
 import categoryReducer from 'modules/categories';
 import { injectAsyncReducers } from 'store';
-import BudgetGrid from 'containers/BudgetGrid';
-import Balance from 'containers/Balance';
+import { withRouter } from 'react-router-dom';
+import ItemPercentage from 'containers/ItemPercentage';
 
 
 // inject reducers that might not have been originally there
@@ -13,11 +14,10 @@ injectAsyncReducers({
   categories: categoryReducer,
 });
 
-const BudgetContainer = () => (
-    <section>
-      <BudgetGrid />
-      <Balance />
-    </section>
+const ItemContainer = () => (
+  <section>
+    <ItemPercentage />
+  </section>
 );
 
-export default BudgetContainer;
+export default ItemContainer;

--- a/app/components/ItemPanel/index.js
+++ b/app/components/ItemPanel/index.js
@@ -1,12 +1,9 @@
 // @flow
 import * as React from 'react';
-import { connect } from 'react-redux';
 import transactionReducer from 'modules/transactions';
 import categoryReducer from 'modules/categories';
 import { injectAsyncReducers } from 'store';
-import { withRouter } from 'react-router-dom';
 import ItemPercentage from 'containers/ItemPercentage';
-
 
 // inject reducers that might not have been originally there
 injectAsyncReducers({

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -5,8 +5,10 @@ import { Switch, Route, Redirect } from 'react-router-dom';
 import ErrorBoundary from 'components/ErrorBoundary';
 import AppError from 'components/AppError';
 import Header from 'components/Header';
+import BudgetGridRow from 'components/BudgetGridRow';
 import Budget from 'routes/Budget';
 import Reports from 'routes/Reports';
+import Item from 'routes/Item';
 import './style.scss';
 
 const App = () => (
@@ -17,6 +19,7 @@ const App = () => (
       <Switch>
         <Route path="/budget" component={Budget} />
         <Route path="/reports" component={Reports} />
+        <Route path="/item/:id" component={Item} />        
         <Redirect to="/budget" />
       </Switch>
     </main>

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -5,7 +5,6 @@ import { Switch, Route, Redirect } from 'react-router-dom';
 import ErrorBoundary from 'components/ErrorBoundary';
 import AppError from 'components/AppError';
 import Header from 'components/Header';
-import BudgetGridRow from 'components/BudgetGridRow';
 import Budget from 'routes/Budget';
 import Reports from 'routes/Reports';
 import Item from 'routes/Item';
@@ -19,7 +18,7 @@ const App = () => (
       <Switch>
         <Route path="/budget" component={Budget} />
         <Route path="/reports" component={Reports} />
-        <Route path="/item/:id" component={Item} />        
+        <Route path="/item/:id" component={Item} />
         <Redirect to="/budget" />
       </Switch>
     </main>

--- a/app/containers/Budget/index.js
+++ b/app/containers/Budget/index.js
@@ -6,7 +6,6 @@ import { injectAsyncReducers } from 'store';
 import BudgetGrid from 'containers/BudgetGrid';
 import Balance from 'containers/Balance';
 
-
 // inject reducers that might not have been originally there
 injectAsyncReducers({
   transactions: transactionReducer,
@@ -14,10 +13,10 @@ injectAsyncReducers({
 });
 
 const BudgetContainer = () => (
-    <section>
-      <BudgetGrid />
-      <Balance />
-    </section>
+  <section>
+    <BudgetGrid />
+    <Balance />
+  </section>
 );
 
 export default BudgetContainer;

--- a/app/containers/ItemPercentage/index.js
+++ b/app/containers/ItemPercentage/index.js
@@ -1,16 +1,13 @@
 // @flow
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { getTransactions } from 'selectors/transactions';
-import { getCategories } from 'selectors/categories';
-import { getItemPercentage } from 'selectors/transactions';
-import type { Transaction } from 'modules/transactions';
-import { getInflowBalance, getOutflowBalance } from 'selectors/transactions';
 import { withRouter } from 'react-router-dom';
+import { getTransactions, getInflowBalance, getOutflowBalance } from 'selectors/transactions';
+import { getCategories } from 'selectors/categories';
+import type { Transaction } from 'modules/transactions';
 import formatAmount from 'utils/formatAmount';
-import styles from './style.scss';
-
 import DonutChart from 'components/DonutChart';
+import styles from './style.scss';
 
 type ItemProps = {
   transactions: Transaction[],
@@ -20,7 +17,7 @@ type ItemProps = {
 export class ItemPercentage extends React.Component<ItemProps> {
   static defaultProps = {
     transactions: [],
-    categories: {}
+    categories: {},
   };
 
   constructor(props) {
@@ -33,45 +30,67 @@ export class ItemPercentage extends React.Component<ItemProps> {
         description: '',
         categoryId: 0,
       },
-    }
+    };
   }
 
   componentWillMount() {
     // Grab the item information based on the page you are looking at in case the user refreshes
-    const item = this.props.transactions.filter( (transaction) => {
-      return transaction.id == this.props.match.params.id
-    })[0];
+    const item = this.props.transactions.filter(
+      transaction => transaction.id === parseInt(this.props.match.params.id, 10)
+    )[0];    
 
-    (item == undefined) ? this.props.history.push('/budget') : this.setState({item});
+    if (item === undefined) {
+      this.props.history.push('/budget');
+    } else {
+      this.setState({ item });
+    }
   }
 
   render() {
-    const { transactions, categories, match, history, inflow, outflow } = this.props;
+    const { categories, history, inflow, outflow } = this.props;
     const { item } = this.state;
-    let item_percentage = 0;
-    let other_total = 0;
+    let itemPercentage = 0;
+    let otherTotal = 0;
 
     // Format the item value to display
     const amount = formatAmount(this.state.item.value);
     const amountCls = amount.isNegative ? styles.neg : styles.pos;
 
     // Calculate how much the item is as a percentage of the total (inflow or outflow)
-    // use other_total to calulate how much the other items take up as a whole of inflow or outflow.
-    amount.isNegative ? item_percentage = (Math.abs(item.value) / outflow) * 100 : item_percentage = ((item.value / inflow) * 100);
-    amount.isNegative ? other_total = (outflow - Math.abs(item.value)) : other_total = (inflow - item.value)
+    // use otherTotal to calulate how much the other items take up as a whole of inflow or outflow.
+    itemPercentage = amount.isNegative ? Math.abs(item.value) / outflow * 100 : item.value / inflow * 100;
+    otherTotal = amount.isNegative ? outflow - Math.abs(item.value) : inflow - item.value;
 
     // Send the data for the chart
     const data = [
-      { id: 1, value: Math.abs(item.value), description: item.description },
-      { id: 2, value: other_total, description: 'Other items'  },
+      {
+        id: 1,
+        value: Math.abs(item.value),
+        description: item.description,
+      },
+      {
+        id: 2,
+        value: otherTotal,
+        description: 'Other items',
+      },
     ];
 
     return (
       <div>
-        <h1>{categories[item.categoryId]}: {item.description}</h1>
-        <h2 className={amountCls}>{amount.text} ({item_percentage.toFixed(2)}%)</h2>
+        <h1>
+          {categories[item.categoryId]}: {item.description}
+        </h1>
+        <h2 className={amountCls}>
+          {amount.text} ({itemPercentage.toFixed(2)}%)
+        </h2>
         <DonutChart data={data} dataLabel="description" dataKey="id" />
-        <button onClick={ () => { history.goBack() } }>Back</button>
+        <button
+          onClick={() => {
+            history.goBack();
+          }}
+        >
+          Back
+        </button>
       </div>
     );
   }

--- a/app/containers/ItemPercentage/index.js
+++ b/app/containers/ItemPercentage/index.js
@@ -1,0 +1,87 @@
+// @flow
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { getTransactions } from 'selectors/transactions';
+import { getCategories } from 'selectors/categories';
+import { getItemPercentage } from 'selectors/transactions';
+import type { Transaction } from 'modules/transactions';
+import { getInflowBalance, getOutflowBalance } from 'selectors/transactions';
+import { withRouter } from 'react-router-dom';
+import formatAmount from 'utils/formatAmount';
+import styles from './style.scss';
+
+import DonutChart from 'components/DonutChart';
+
+type ItemProps = {
+  transactions: Transaction[],
+  categories: Object,
+};
+
+export class ItemPercentage extends React.Component<ItemProps> {
+  static defaultProps = {
+    transactions: [],
+    categories: {}
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      item: {
+        id: 0,
+        value: 0,
+        description: '',
+        categoryId: 0,
+      },
+    }
+  }
+
+  componentWillMount() {
+    // Grab the item information based on the page you are looking at in case the user refreshes
+    const item = this.props.transactions.filter( (transaction) => {
+      return transaction.id == this.props.match.params.id
+    })[0];
+
+    (item == undefined) ? this.props.history.push('/budget') : this.setState({item});
+  }
+
+  render() {
+    const { transactions, categories, match, history, inflow, outflow } = this.props;
+    const { item } = this.state;
+    let item_percentage = 0;
+    let other_total = 0;
+
+    // Format the item value to display
+    const amount = formatAmount(this.state.item.value);
+    const amountCls = amount.isNegative ? styles.neg : styles.pos;
+
+    // Calculate how much the item is as a percentage of the total (inflow or outflow)
+    // use other_total to calulate how much the other items take up as a whole of inflow or outflow.
+    amount.isNegative ? item_percentage = (Math.abs(item.value) / outflow) * 100 : item_percentage = ((item.value / inflow) * 100);
+    amount.isNegative ? other_total = (outflow - Math.abs(item.value)) : other_total = (inflow - item.value)
+
+    // Send the data for the chart
+    const data = [
+      { id: 1, value: Math.abs(item.value), description: item.description },
+      { id: 2, value: other_total, description: 'Other items'  },
+    ];
+
+    return (
+      <div>
+        <h1>{categories[item.categoryId]}: {item.description}</h1>
+        <h2 className={amountCls}>{amount.text} ({item_percentage.toFixed(2)}%)</h2>
+        <DonutChart data={data} dataLabel="description" dataKey="id" />
+        <button onClick={ () => { history.goBack() } }>Back</button>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  transactions: getTransactions(state),
+  categories: getCategories(state),
+  inflow: getInflowBalance(state),
+  outflow: Math.abs(getOutflowBalance(state)),
+});
+
+export default withRouter(connect(mapStateToProps)(ItemPercentage));

--- a/app/containers/ItemPercentage/index.js
+++ b/app/containers/ItemPercentage/index.js
@@ -37,7 +37,7 @@ export class ItemPercentage extends React.Component<ItemProps> {
     // Grab the item information based on the page you are looking at in case the user refreshes
     const item = this.props.transactions.filter(
       transaction => transaction.id === parseInt(this.props.match.params.id, 10)
-    )[0];    
+    )[0];
 
     if (item === undefined) {
       this.props.history.push('/budget');

--- a/app/containers/ItemPercentage/style.scss
+++ b/app/containers/ItemPercentage/style.scss
@@ -1,0 +1,9 @@
+@import 'theme/variables';
+
+.neg {
+  color: $red;
+}
+
+.pos {
+  color: $green;
+}

--- a/app/routes/Item/index.js
+++ b/app/routes/Item/index.js
@@ -1,0 +1,10 @@
+// @flow
+import React from 'react';
+
+import Chunk from 'components/Chunk';
+
+const loadItemPanel = () => import('components/ItemPanel' /* webpackChunkName: "item" */);
+
+const Item = () => <Chunk load={loadItemPanel} />;
+
+export default Item;


### PR DESCRIPTION
## Feature 
As a user, I want to see percentage of total budget an item is contributing with, so I can better understand statistics of my inflow or outflow items 

## Proposed Changes
* Make budget items clickable
* When they clicked, load a separate page with a title corresponding to the item details 
* The route should be dynamic with an item ID in it 
* A subtitle under title should show percentage with red minus sign showing outflow, green plus sign for inflow
* A pie chart showing how much of the entire budget this item is contributing with should be on that page
* No other items from the budget should be on that pie chart 
* There should be a back button to return back to the previous route
* The view should be mobile and desktop compatible

## Screenshot
![new_feature](https://user-images.githubusercontent.com/5061223/32578232-733a6a8a-c4aa-11e7-9c61-d5e99d76f8ea.png)


## Checklist

* [x] Feature developed
* [x] Created/updated unit tests
* [x] Comments in code
* [ ] Documentation written
