### PR TITLE
Feature: Added Transaction Contribution Details Page - Thomas Asenov

### DIFF
--- a/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<tr>
+<tr
+  onClick={[Function]}
+>
   <td>
     <div
       className="cellLabel"

--- a/app/components/BudgetGridRow/__tests__/index-test.js
+++ b/app/components/BudgetGridRow/__tests__/index-test.js
@@ -15,6 +15,8 @@ it('renders correctly', () => {
     2: 'School',
   };
 
-  const tree = renderer.create(<BudgetGridRow transaction={mockTransaction} categories={mockCategories} />).toJSON();
+  const tree = renderer
+    .create(<BudgetGridRow transaction={mockTransaction} categories={mockCategories} clickHandler={() => {}} />)
+    .toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -8,16 +8,17 @@ import styles from './style.scss';
 type BudgetGridRowProps = {
   transaction: Transaction,
   categories: Categories,
+  clickHandler: Function,
 };
 
-const BudgetGridRow = ({ transaction, categories }: BudgetGridRowProps) => {
+const BudgetGridRow = ({ transaction, categories, clickHandler }: BudgetGridRowProps) => {
   const amount = formatAmount(transaction.value);
   const amountCls = amount.isNegative ? styles.neg : styles.pos;
   const { id, categoryId, description } = transaction;
   const category = categories[categoryId];
 
   return (
-    <tr key={id}>
+    <tr key={id} onClick={() => {clickHandler(id)}}>
       <td>
         <div className={styles.cellLabel}>Category</div>
         <div className={styles.cellContent}>{category}</div>

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -18,7 +18,12 @@ const BudgetGridRow = ({ transaction, categories, clickHandler }: BudgetGridRowP
   const category = categories[categoryId];
 
   return (
-    <tr key={id} onClick={() => {clickHandler(id)}}>
+    <tr
+      key={id}
+      onClick={() => {
+        clickHandler(id);
+      }}
+    >
       <td>
         <div className={styles.cellLabel}>Category</div>
         <div className={styles.cellContent}>{category}</div>

--- a/app/components/BudgetGridRow/style.scss
+++ b/app/components/BudgetGridRow/style.scss
@@ -12,6 +12,7 @@
 
 .cellContent {
   flex: 1;
+  cursor: pointer;
 }
 
 .neg {

--- a/app/components/DonutChart/index.js
+++ b/app/components/DonutChart/index.js
@@ -61,7 +61,7 @@ class DonutChart extends React.Component<DonutChartProps> {
     const { data, dataValue, color, height } = this.props;
 
     this.chart = pie()
-      .value(d => d[dataValue])
+      .value(d => Math.abs(d[dataValue]))
       .sort(null);
     this.outerRadius = height / 2;
     this.pathArc = this.getPathArc();

--- a/app/components/ReportsPanel/index.js
+++ b/app/components/ReportsPanel/index.js
@@ -6,6 +6,7 @@ import categoryReducer from 'modules/categories';
 import { injectAsyncReducers } from 'store';
 import InflowOutflow from 'containers/InflowOutflow';
 import Spending from 'containers/Spending';
+import ItemDetails from 'containers/ItemDetails';
 import ReportsTabbar from './ReportsTabbar';
 
 // inject reducers that might not have been originally there
@@ -21,6 +22,7 @@ const ReportsPanel = () => (
     <Switch>
       <Route path="/reports/inflow-outflow" component={InflowOutflow} />
       <Route path="/reports/spending" component={Spending} />
+      <Route path="/reports/item-details/:itemId" component={ItemDetails} />
       <Redirect to="/reports/inflow-outflow" />
     </Switch>
   </section>

--- a/app/components/ReportsPanel/style.scss
+++ b/app/components/ReportsPanel/style.scss
@@ -3,8 +3,6 @@
 .tabbar {
   border: $border;
   border-radius: 6px;
-  display: flex;
-  flex-direction: row;
   max-height: 3em;
   margin-bottom: 2em;
 }

--- a/app/containers/BudgetGrid/index.js
+++ b/app/containers/BudgetGrid/index.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { withRouter } from "react-router-dom";
+import { withRouter } from 'react-router-dom';
 import { getTransactions } from 'selectors/transactions';
 import { getCategories } from 'selectors/categories';
 import EntryFormRow from 'containers/EntryFormRow';
@@ -46,8 +46,12 @@ export class BudgetGrid extends React.Component<BudgetGridProps> {
         </thead>
         <tbody>
           {transactions.map((transaction: Transaction): React.Element<any> => (
-            <BudgetGridRow key={transaction.id} transaction={transaction}
-                           categories={categories} clickHandler={this.handleItemClick} />
+            <BudgetGridRow
+              key={transaction.id}
+              transaction={transaction}
+              categories={categories}
+              clickHandler={this.handleItemClick}
+            />
           ))}
         </tbody>
         <tfoot>

--- a/app/containers/BudgetGrid/index.js
+++ b/app/containers/BudgetGrid/index.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { withRouter } from "react-router-dom";
 import { getTransactions } from 'selectors/transactions';
 import { getCategories } from 'selectors/categories';
 import EntryFormRow from 'containers/EntryFormRow';
@@ -19,6 +20,18 @@ export class BudgetGrid extends React.Component<BudgetGridProps> {
     categories: {},
   };
 
+  constructor(props) {
+    super(props);
+
+    this.handleItemClick = this.handleItemClick.bind(this);
+  }
+
+  handleItemClick(itemId) {
+    const { history } = this.props;
+    const path = `/reports/item-details/${itemId}`;
+    history.push(path);
+  }
+
   render() {
     const { transactions, categories } = this.props;
 
@@ -33,7 +46,8 @@ export class BudgetGrid extends React.Component<BudgetGridProps> {
         </thead>
         <tbody>
           {transactions.map((transaction: Transaction): React.Element<any> => (
-            <BudgetGridRow key={transaction.id} transaction={transaction} categories={categories} />
+            <BudgetGridRow key={transaction.id} transaction={transaction}
+                           categories={categories} clickHandler={this.handleItemClick} />
           ))}
         </tbody>
         <tfoot>
@@ -49,4 +63,4 @@ const mapStateToProps = state => ({
   categories: getCategories(state),
 });
 
-export default connect(mapStateToProps)(BudgetGrid);
+export default connect(mapStateToProps)(withRouter(BudgetGrid));

--- a/app/containers/ItemDetails/index.js
+++ b/app/containers/ItemDetails/index.js
@@ -16,6 +16,8 @@ type ItemDetailsProps = {
 class ItemDetails extends React.Component<ItemDetailsProps> {
   render() {
     const { data } = this.props;
+
+    // Make chart data to show this item and rest transaction amounts
     const donutData = [
       {
         id: data.id,

--- a/app/containers/ItemDetails/index.js
+++ b/app/containers/ItemDetails/index.js
@@ -1,0 +1,22 @@
+// @flow
+import * as React from 'react';
+import { connect } from 'react-redux';
+import type { TransactionSummary } from 'selectors/transactions';
+
+import { sortTransactions, getOutflowByCategoryName } from 'selectors/transactions';
+
+type SpendingProps = {
+  data: TransactionSummary[],
+};
+
+class ItemDetails extends React.Component<SpendingProps> {
+  render() {
+    return (<div></div>);
+  }
+}
+
+const mapStateToProps = state => ({
+  data: sortTransactions(getOutflowByCategoryName(state)),
+});
+
+export default connect(mapStateToProps)(ItemDetails);

--- a/app/containers/ItemDetails/index.js
+++ b/app/containers/ItemDetails/index.js
@@ -1,22 +1,50 @@
 // @flow
 import * as React from 'react';
 import { connect } from 'react-redux';
-import type { TransactionSummary } from 'selectors/transactions';
+import { Link } from 'react-router-dom';
+import type { TransactionContribution } from 'selectors/transactions';
+import { getTransactionContribution } from 'selectors/transactions';
 
-import { sortTransactions, getOutflowByCategoryName } from 'selectors/transactions';
+import DonutChart from 'components/DonutChart';
 
-type SpendingProps = {
-  data: TransactionSummary[],
+import styles from './style.scss';
+
+type ItemDetailsProps = {
+  data: TransactionContribution,
 };
 
-class ItemDetails extends React.Component<SpendingProps> {
+class ItemDetails extends React.Component<ItemDetailsProps> {
   render() {
-    return (<div></div>);
+    const { data } = this.props;
+    const donutData = [{
+      id: data.id,
+      value: data.value,
+      description: data.description,
+    }, {
+      id: data.id + 1,
+      value: data.totalTransactionOfFlow - data.value,
+      description: 'Others',
+    }];
+
+    return (
+      <div className={styles.itemDetails}>
+        <Link to="/budget">Go Back</Link>
+        <h2>{data.description}</h2>
+        <h3>
+          {data.value < 0?
+            <span className={styles.red}>-</span>:
+            <span className={styles.green}>+</span>
+          }
+          {data.percentage}%
+        </h3>
+        <DonutChart data={donutData} dataLabel="description" dataKey="id" />
+      </div>
+    );
   }
 }
 
-const mapStateToProps = state => ({
-  data: sortTransactions(getOutflowByCategoryName(state)),
+const mapStateToProps = (state, props) => ({
+  data: getTransactionContribution(state, parseInt(props.match.params.itemId)),
 });
 
 export default connect(mapStateToProps)(ItemDetails);

--- a/app/containers/ItemDetails/index.js
+++ b/app/containers/ItemDetails/index.js
@@ -16,25 +16,25 @@ type ItemDetailsProps = {
 class ItemDetails extends React.Component<ItemDetailsProps> {
   render() {
     const { data } = this.props;
-    const donutData = [{
-      id: data.id,
-      value: data.value,
-      description: data.description,
-    }, {
-      id: data.id + 1,
-      value: data.totalTransactionOfFlow - data.value,
-      description: 'Others',
-    }];
+    const donutData = [
+      {
+        id: data.id,
+        value: data.value,
+        description: data.description,
+      },
+      {
+        id: data.id + 1,
+        value: data.totalTransactionOfFlow - data.value,
+        description: 'Others',
+      },
+    ];
 
     return (
       <div className={styles.itemDetails}>
         <Link to="/budget">Go Back</Link>
         <h2>{data.description}</h2>
         <h3>
-          {data.value < 0?
-            <span className={styles.red}>-</span>:
-            <span className={styles.green}>+</span>
-          }
+          {data.value < 0 ? <span className={styles.red}>-</span> : <span className={styles.green}>+</span>}
           {data.percentage}%
         </h3>
         <DonutChart data={donutData} dataLabel="description" dataKey="id" />
@@ -44,7 +44,7 @@ class ItemDetails extends React.Component<ItemDetailsProps> {
 }
 
 const mapStateToProps = (state, props) => ({
-  data: getTransactionContribution(state, parseInt(props.match.params.itemId)),
+  data: getTransactionContribution(state, parseInt(props.match.params.itemId, 10)),
 });
 
 export default connect(mapStateToProps)(ItemDetails);

--- a/app/containers/ItemDetails/style.scss
+++ b/app/containers/ItemDetails/style.scss
@@ -1,0 +1,17 @@
+@import 'theme/variables';
+
+.itemDetails {
+  h2, h3 {
+    text-align: center;
+  }
+  display: flex;
+  flex-direction: column;
+}
+
+.red {
+  color: red;
+}
+
+.green {
+  color: green;
+}

--- a/app/selectors/transactions.js
+++ b/app/selectors/transactions.js
@@ -12,6 +12,14 @@ export type TransactionSummary = {
   category?: string,
 };
 
+export type TransactionContribution = {
+  id: number,
+  value: number,
+  description: string,
+  percentage: number,
+  totalTransactionOfFlow: number,
+};
+
 function totalTransactions(transactions: Transaction[]): number {
   return transactions.reduce((total, item) => total + parseFloat(item.value), 0);
 }
@@ -38,6 +46,8 @@ const applyCategoryName = (transactions: TransactionSummary[], categories) =>
   });
 
 export const getTransactions = (state: State): Transaction[] => state.transactions || [];
+export const getTransaction = (state: State, id: number): Transaction =>
+  state.transactions.find(iterator => (iterator.id === id)) || {};
 
 const getInflowTransactions = createSelector([getTransactions], transactions =>
   transactions.filter(item => item.value > 0)
@@ -78,3 +88,25 @@ export const getOutflowByCategoryName = createSelector(getOutflowByCategory, get
 export const getInflowByCategoryName = createSelector(getInflowByCategory, getCategories, (trans, cat) =>
   applyCategoryName(trans, cat)
 );
+
+export const getTransactionContribution = createSelector([getTransaction, getInflowBalance, getOutflowBalance],
+  (transaction, inflowBalance, outflowBalance) => {
+    let percentage = 0;
+    let totalTransactionOfFlow = 0;
+
+    if (transaction.value < 0) {
+      percentage = parseFloat((100 * transaction.value / outflowBalance).toFixed(2));
+      totalTransactionOfFlow = outflowBalance;
+    } else {
+      percentage = parseFloat((100 * transaction.value / inflowBalance).toFixed(2));
+      totalTransactionOfFlow = inflowBalance;
+    }
+
+    return {
+      id: transaction.id,
+      value: transaction.value,
+      description: transaction.description,
+      percentage,
+      totalTransactionOfFlow,
+    };
+});

--- a/app/selectors/transactions.js
+++ b/app/selectors/transactions.js
@@ -47,7 +47,7 @@ const applyCategoryName = (transactions: TransactionSummary[], categories) =>
 
 export const getTransactions = (state: State): Transaction[] => state.transactions || [];
 export const getTransaction = (state: State, id: number): Transaction =>
-  state.transactions.find(iterator => (iterator.id === id)) || {};
+  state.transactions.find(iterator => iterator.id === id) || {};
 
 const getInflowTransactions = createSelector([getTransactions], transactions =>
   transactions.filter(item => item.value > 0)
@@ -89,7 +89,8 @@ export const getInflowByCategoryName = createSelector(getInflowByCategory, getCa
   applyCategoryName(trans, cat)
 );
 
-export const getTransactionContribution = createSelector([getTransaction, getInflowBalance, getOutflowBalance],
+export const getTransactionContribution = createSelector(
+  [getTransaction, getInflowBalance, getOutflowBalance],
   (transaction, inflowBalance, outflowBalance) => {
     let percentage = 0;
     let totalTransactionOfFlow = 0;
@@ -109,4 +110,5 @@ export const getTransactionContribution = createSelector([getTransaction, getInf
       percentage,
       totalTransactionOfFlow,
     };
-});
+  }
+);


### PR DESCRIPTION
## Proposed Changes

* Created item details page/routing
* Displayed percentage of total budget an item is contributing with by text and pie chart
* Made this page responsive

## Snapshot
![snap](https://user-images.githubusercontent.com/17303792/32826976-292ce938-c9f3-11e7-8da8-c4cc2a8ae467.png)

## Checklist
- [x] Create new page with a title corresponding to the item details user clicked on the budget grid 
- [x] The new page route should be dynamic with item ID in it 
- [x] Display subtitle under title as a percentage with red minus sign showing outflow, green plus sign for inflow 
- [x] Draw a pie chart showing how much of the entire budget this item is contributing with
- [x] No other items from the budget should be on that pie chart 
- [x] Put a back button to return back to the previous route 
- [x] Make the view mobile and desktop compatible 
- [x] Comments in code