### PR TITLE
Gp code test

### DIFF
--- a/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<tr>
+<tr
+  onClick={[Function]}
+>
   <td>
     <div
       className="cellLabel"

--- a/app/components/BudgetGridRow/__tests__/index-test.js
+++ b/app/components/BudgetGridRow/__tests__/index-test.js
@@ -15,6 +15,10 @@ it('renders correctly', () => {
     2: 'School',
   };
 
-  const tree = renderer.create(<BudgetGridRow transaction={mockTransaction} categories={mockCategories} />).toJSON();
+  const mockClick = () => {};
+
+  const tree = renderer
+    .create(<BudgetGridRow transaction={mockTransaction} categories={mockCategories} onClick={mockClick} />)
+    .toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import formatAmount from 'utils/formatAmount';
 import type { Transaction } from 'modules/transactions';
 import type { Categories } from 'modules/categories';
@@ -15,6 +16,7 @@ const BudgetGridRow = ({ transaction, categories }: BudgetGridRowProps) => {
   const amountCls = amount.isNegative ? styles.neg : styles.pos;
   const { id, categoryId, description } = transaction;
   const category = categories[categoryId];
+  const detailLink = `/budget/item/${id}`;
 
   return (
     <tr key={id}>
@@ -24,7 +26,9 @@ const BudgetGridRow = ({ transaction, categories }: BudgetGridRowProps) => {
       </td>
       <td>
         <div className={styles.cellLabel}>Description</div>
-        <div className={styles.cellContent}>{description}</div>
+        <Link to={detailLink}>
+          <div className={styles.cellContent}>{description}</div>
+        </Link>
       </td>
       <td className={amountCls}>
         <div className={styles.cellLabel}>Amount</div>

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import formatAmount from 'utils/formatAmount';
 import type { Transaction } from 'modules/transactions';
 import type { Categories } from 'modules/categories';
@@ -9,26 +8,24 @@ import styles from './style.scss';
 type BudgetGridRowProps = {
   transaction: Transaction,
   categories: Categories,
+  onClick: Function,
 };
 
-const BudgetGridRow = ({ transaction, categories }: BudgetGridRowProps) => {
+const BudgetGridRow = ({ transaction, categories, onClick }: BudgetGridRowProps) => {
   const amount = formatAmount(transaction.value);
   const amountCls = amount.isNegative ? styles.neg : styles.pos;
   const { id, categoryId, description } = transaction;
   const category = categories[categoryId];
-  const detailLink = `/budget/item/${id}`;
 
   return (
-    <tr key={id}>
+    <tr key={id} onClick={onClick}>
       <td>
         <div className={styles.cellLabel}>Category</div>
         <div className={styles.cellContent}>{category}</div>
       </td>
       <td>
         <div className={styles.cellLabel}>Description</div>
-        <Link to={detailLink}>
-          <div className={styles.cellContent}>{description}</div>
-        </Link>
+        <div className={styles.cellContent}>{description}</div>
       </td>
       <td className={amountCls}>
         <div className={styles.cellLabel}>Amount</div>

--- a/app/components/BudgetItem/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/BudgetItem/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,90 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<section>
+  <div>
+    <button
+      onClick={undefined}
+    >
+      Back
+    </button>
+  </div>
+  <h1>
+    Trader Joe's food
+     (
+    -$423.34
+    )
+  </h1>
+  <h3>
+    <span
+      className="redText"
+    >
+      -
+    </span>
+    20%
+  </h3>
+  <div
+    className="donutChart"
+  >
+    <svg
+      className="mainSvg"
+      height={316}
+      viewBox="-8 -8 316 316"
+      width={316}
+    >
+      <g
+        transform="translate(150,150)"
+      >
+        <path
+          d="M9.184850993605149e-15,-150A150,150,0,0,1,142.65847744427302,-46.35254915624211L71.32923872213651,-23.176274578121056A75,75,0,0,0,4.592425496802574e-15,-75Z"
+          fill="#9467bd"
+        />
+        <path
+          d="M142.65847744427302,-46.35254915624211A150,150,0,1,1,-2.7554552980815446e-14,-150L-1.3777276490407723e-14,-75A75,75,0,1,0,71.32923872213651,-23.176274578121056Z"
+          fill="#aec7e8"
+        />
+      </g>
+    </svg>
+    <ul
+      className="legend"
+    >
+      <li
+        style={
+          Object {
+            "color": "#9467bd",
+          }
+        }
+      >
+        <span>
+          This
+        </span>
+        <span
+          className="value"
+        >
+           
+          20%
+           
+        </span>
+      </li>
+      <li
+        style={
+          Object {
+            "color": "#aec7e8",
+          }
+        }
+      >
+        <span>
+          Total
+        </span>
+        <span
+          className="value"
+        >
+           
+          80%
+           
+        </span>
+      </li>
+    </ul>
+  </div>
+</section>
+`;

--- a/app/components/BudgetItem/__tests__/index-test.js
+++ b/app/components/BudgetItem/__tests__/index-test.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import BudgetItem from 'components/BudgetItem';
+
+it('renders correctly', () => {
+  const mockTransaction = {
+    id: 1,
+    description: "Trader Joe's food",
+    value: -423.34,
+    categoryId: 1,
+  };
+
+  const mockContribution = {
+    flowTotal: 1000,
+    percent: 20,
+  };
+
+  const mockClick = () => {};
+
+  const tree = renderer
+    .create(<BudgetItem transaction={mockTransaction} contribution={mockContribution} />)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/components/BudgetItem/index.js
+++ b/app/components/BudgetItem/index.js
@@ -1,7 +1,10 @@
 // @flow
 import * as React from 'react';
+import formatAmount from 'utils/formatAmount';
+
 import { Route, Link } from 'react-router-dom';
 import DonutChart from 'components/DonutChart';
+import styles from './style.scss';
 
 type BugdetDetailsProps = {
   transaction: Transaction,
@@ -12,21 +15,27 @@ const BudgetItem = ({ transaction, contribution }: BugdetDetailsProps) => {
   const chartData = [
     {
       value: parseFloat(contribution.percent),
-      label: 'This'
+      label: 'This',
     },
     {
       value: 100 - parseFloat(contribution.percent),
-      label: 'Total'
-    }
+      label: 'Total',
+    },
   ];
   return (
     <section>
       <Route>
         <Link to="/budget">Back</Link>
       </Route>
-      <h1>{transaction.description}</h1>
+      <h1>
+        {transaction.description}
+        &nbsp;({formatAmount(transaction.value).text})
+      </h1>
       <h3>
-        {transaction.value}({contribution.percent}%)
+        <span className={transaction.value < 0 ? styles.redText : styles.greenText}>
+          {transaction.value > 0 ? '+' : '-'}
+        </span>
+        {formatAmount(contribution.percent, false, true).text}
       </h3>
       <DonutChart data={chartData} dataLabel="label" dataKey="label" valueAsPercent="true" />
     </section>

--- a/app/components/BudgetItem/index.js
+++ b/app/components/BudgetItem/index.js
@@ -1,0 +1,13 @@
+// @flow
+import * as React from 'react';
+
+type BugdetDetailsProps = {
+  transaction: Transaction
+};
+
+const BudgetItem = ({ transaction }: BugdetDetailsProps) => {
+  const value = transaction.value;
+  return <span>{value}</span>;
+};
+
+export default BudgetItem;

--- a/app/components/BudgetItem/index.js
+++ b/app/components/BudgetItem/index.js
@@ -9,9 +9,10 @@ import styles from './style.scss';
 type BugdetDetailsProps = {
   transaction: Transaction,
   contribution: Object,
+  goBackHandler: Function,
 };
 
-const BudgetItem = ({ transaction, contribution }: BugdetDetailsProps) => {
+const BudgetItem = ({ transaction, contribution, goBackHandler }: BugdetDetailsProps) => {
   const chartData = [
     {
       value: parseFloat(contribution.percent),
@@ -24,9 +25,9 @@ const BudgetItem = ({ transaction, contribution }: BugdetDetailsProps) => {
   ];
   return (
     <section>
-      <Route>
-        <Link to="/budget">Back</Link>
-      </Route>
+      <div>
+        <button onClick={goBackHandler}>Back</button>
+      </div>
       <h1>
         {transaction.description}
         &nbsp;({formatAmount(transaction.value).text})

--- a/app/components/BudgetItem/index.js
+++ b/app/components/BudgetItem/index.js
@@ -12,7 +12,7 @@ const BudgetItem = ({ transaction, contribution }: BugdetDetailsProps) => {
   const chartData = [
     {
       value: parseFloat(contribution.percent),
-      label: transaction.description
+      label: 'This'
     },
     {
       value: 100 - parseFloat(contribution.percent),
@@ -28,7 +28,7 @@ const BudgetItem = ({ transaction, contribution }: BugdetDetailsProps) => {
       <h3>
         {transaction.value}({contribution.percent}%)
       </h3>
-      <DonutChart data={chartData} dataLabel="label" dataKey="label" isPercentage />
+      <DonutChart data={chartData} dataLabel="label" dataKey="label" valueAsPercent="true" />
     </section>
   );
 };

--- a/app/components/BudgetItem/index.js
+++ b/app/components/BudgetItem/index.js
@@ -1,5 +1,8 @@
 // @flow
 import * as React from 'react';
+import { Route } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import DonutChart from 'components/DonutChart';
 
 type BugdetDetailsProps = {
   transaction: Transaction,
@@ -7,15 +10,26 @@ type BugdetDetailsProps = {
 };
 
 const BudgetItem = ({ transaction, contribution }: BugdetDetailsProps) => {
-  const value = transaction.value;
-  const percent = contribution.percent;
-
+  const chartData = [
+    {
+      value: parseFloat(contribution.percent),
+      label: transaction.description
+    },
+    {
+      value: 100 - parseFloat(contribution.percent),
+      label: 'Total'
+    }
+  ];
   return (
     <section>
+      <Route>
+        <Link to="/budget">Back</Link>
+      </Route>
       <h1>{transaction.description}</h1>
       <h3>
         {transaction.value}({contribution.percent}%)
       </h3>
+      <DonutChart data={chartData} dataLabel="label" dataKey="label" isPercentage />
     </section>
   );
 };

--- a/app/components/BudgetItem/index.js
+++ b/app/components/BudgetItem/index.js
@@ -2,12 +2,22 @@
 import * as React from 'react';
 
 type BugdetDetailsProps = {
-  transaction: Transaction
+  transaction: Transaction,
+  contribution: Object,
 };
 
-const BudgetItem = ({ transaction }: BugdetDetailsProps) => {
+const BudgetItem = ({ transaction, contribution }: BugdetDetailsProps) => {
   const value = transaction.value;
-  return <span>{value}</span>;
+  const percent = contribution.percent;
+
+  return (
+    <section>
+      <h1>{transaction.description}</h1>
+      <h3>
+        {transaction.value}({contribution.percent}%)
+      </h3>
+    </section>
+  );
 };
 
 export default BudgetItem;

--- a/app/components/BudgetItem/index.js
+++ b/app/components/BudgetItem/index.js
@@ -1,7 +1,6 @@
 // @flow
 import * as React from 'react';
-import { Route } from 'react-router-dom';
-import { Link } from 'react-router-dom';
+import { Route, Link } from 'react-router-dom';
 import DonutChart from 'components/DonutChart';
 
 type BugdetDetailsProps = {

--- a/app/components/BudgetItem/style.scss
+++ b/app/components/BudgetItem/style.scss
@@ -1,0 +1,8 @@
+@import 'theme/variables';
+
+.redText{
+  color:$red;
+}
+.greenText{
+  color:$green;
+}

--- a/app/components/DonutChart/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/DonutChart/__tests__/__snapshots__/index-test.js.snap
@@ -16,6 +16,7 @@ exports[`renders correctly 1`] = `
     dataKey="test"
     dataLabel="test"
     dataValue="value"
+    valueAsPercent={false}
   />
 </div>
 `;

--- a/app/components/DonutChart/__tests__/index-test.js
+++ b/app/components/DonutChart/__tests__/index-test.js
@@ -8,6 +8,6 @@ jest.mock('components/Chart', () => 'div');
 jest.mock('components/Legend', () => 'div');
 
 it('renders correctly', () => {
-  const tree = renderer.create(<DonutChart dataLabel="test" dataKey="test" data={[]} />).toJSON();
+  const tree = renderer.create(<DonutChart dataLabel="test" dataKey="test" data={[]} valueAsPercent={false}/>).toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/app/components/DonutChart/index.js
+++ b/app/components/DonutChart/index.js
@@ -19,6 +19,7 @@ type DonutChartProps = {
   color: Function,
   height: number,
   innerRatio: number,
+  valueAsPercent: boolean,
 };
 
 class DonutChart extends React.Component<DonutChartProps> {
@@ -27,6 +28,7 @@ class DonutChart extends React.Component<DonutChartProps> {
     height: 300,
     innerRatio: 4,
     dataValue: 'value',
+    valueAsPercent: false,
   };
 
   componentWillMount() {
@@ -70,7 +72,7 @@ class DonutChart extends React.Component<DonutChartProps> {
   };
 
   render() {
-    const { data, dataLabel, dataValue, dataKey } = this.props;
+    const { data, dataLabel, dataValue, dataKey, valueAsPercent } = this.props;
     const { outerRadius, pathArc, colorFn, boxLength, chartPadding } = this;
 
     return (
@@ -86,7 +88,7 @@ class DonutChart extends React.Component<DonutChartProps> {
           ))}
         </Chart>
 
-        <Legend color={colorFn} {...{ data, dataValue, dataLabel, dataKey }} />
+        <Legend color={colorFn} {...{ data, dataValue, dataLabel, dataKey }} valueAsPercent={valueAsPercent} />
       </div>
     );
   }

--- a/app/components/Legend/LegendItem.js
+++ b/app/components/Legend/LegendItem.js
@@ -7,12 +7,12 @@ type LegendItemProps = {
   color: string,
   value: number,
   label: string,
+  isPercent: boolean,
 };
-
-const LegendItem = ({ color, label, value }: LegendItemProps) => (
+const LegendItem = ({ color, label, value, isPercent }: LegendItemProps) => (
   <li style={{ color }}>
     <span>{label}</span>
-    <span className={styles.value}> {formatAmount(value).text} </span>
+    <span className={styles.value}> {formatAmount(value, null, isPercent).text} </span>
   </li>
 );
 

--- a/app/components/Legend/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/Legend/__tests__/__snapshots__/index-test.js.snap
@@ -6,11 +6,13 @@ exports[`renders correctly 1`] = `
 >
   <div
     color={undefined}
+    isPercent={undefined}
     label={undefined}
     value={undefined}
   />
   <div
     color={undefined}
+    isPercent={undefined}
     label={undefined}
     value={undefined}
   />

--- a/app/components/Legend/__tests__/index-test.js
+++ b/app/components/Legend/__tests__/index-test.js
@@ -9,7 +9,7 @@ it('renders correctly', () => {
   const mockData = [{ key: 1 }, { key: 2 }];
 
   const tree = renderer
-    .create(<Legend data={mockData} dataValue="test" dataLabel="test" dataKey="key" color={() => {}} />)
+    .create(<Legend data={mockData} dataValue="test" dataLabel="test" dataKey="key" color={() => {}} isPercent="false" />)
     .toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/app/components/Legend/index.js
+++ b/app/components/Legend/index.js
@@ -12,12 +12,18 @@ type LegendType = {
   dataKey: string,
   color: Function,
   reverse: boolean,
+  valueAsPercent: boolean,
 };
 
-const Legend = ({ data, color, dataValue, dataLabel, dataKey, reverse }: LegendType) => (
+const Legend = ({ data, color, dataValue, dataLabel, dataKey, reverse, valueAsPercent }: LegendType) => (
   <ul className={cx(styles.legend, { [styles.reverse]: reverse })}>
     {data.map((item, idx) => (
-      <LegendItem color={color(idx)} key={item[dataKey]} label={item[dataLabel]} value={item[dataValue]} />
+      <LegendItem
+        color={color(idx)}
+        key={item[dataKey]}
+        label={item[dataLabel]}
+        value={item[dataValue]}
+        isPercent={valueAsPercent}/>
     ))}
   </ul>
 );

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -6,6 +6,7 @@ import ErrorBoundary from 'components/ErrorBoundary';
 import AppError from 'components/AppError';
 import Header from 'components/Header';
 import Budget from 'routes/Budget';
+import BudgetItem from 'routes/BudgetItem';
 import Reports from 'routes/Reports';
 import './style.scss';
 
@@ -16,6 +17,7 @@ const App = () => (
 
       <Switch>
         <Route path="/budget" component={Budget} />
+        <Route path="/budget/item/:id" component={BudgetItem} />
         <Route path="/reports" component={Reports} />
         <Redirect to="/budget" />
       </Switch>

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -16,7 +16,7 @@ const App = () => (
       <Header />
 
       <Switch>
-        <Route path="/budget" component={Budget} />
+        <Route path="/budget" component={Budget} exact/>
         <Route path="/budget/item/:id" component={BudgetItem} />
         <Route path="/reports" component={Reports} />
         <Redirect to="/budget" />

--- a/app/containers/BudgetGrid/index.js
+++ b/app/containers/BudgetGrid/index.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { getTransactions } from 'selectors/transactions';
 import { getCategories } from 'selectors/categories';
@@ -11,6 +12,7 @@ import styles from './style.scss';
 type BudgetGridProps = {
   transactions: Transaction[],
   categories: Object,
+  history: Object,
 };
 
 export class BudgetGrid extends React.Component<BudgetGridProps> {
@@ -19,9 +21,17 @@ export class BudgetGrid extends React.Component<BudgetGridProps> {
     categories: {},
   };
 
+  constructor(props) {
+    super(props);
+    this.handleRowClick = this.handleRowClick.bind(this);
+  }
+
+  handleRowClick = (transaction: Transaction) => {
+    this.props.history.push(`/budget/item/${transaction.id}`);
+  };
+
   render() {
     const { transactions, categories } = this.props;
-
     return (
       <table className={styles.budgetGrid}>
         <thead>
@@ -33,7 +43,13 @@ export class BudgetGrid extends React.Component<BudgetGridProps> {
         </thead>
         <tbody>
           {transactions.map((transaction: Transaction): React.Element<any> => (
-            <BudgetGridRow key={transaction.id} transaction={transaction} categories={categories} />
+            <BudgetGridRow
+              key={transaction.id}
+              transaction={transaction}
+              categories={categories}
+              onClick={() => {
+                this.handleRowClick(transaction);
+              }} />
           ))}
         </tbody>
         <tfoot>
@@ -49,4 +65,4 @@ const mapStateToProps = state => ({
   categories: getCategories(state),
 });
 
-export default connect(mapStateToProps)(BudgetGrid);
+export default withRouter(connect(mapStateToProps)(BudgetGrid));

--- a/app/containers/BudgetItem/index.js
+++ b/app/containers/BudgetItem/index.js
@@ -1,18 +1,24 @@
 // @flow
 import * as React from 'react';
-import transactionReducer from 'modules/transactions';
 import { injectAsyncReducers } from 'store';
+import { connect } from 'react-redux';
 import BudgetItem from 'components/BudgetItem';
+import type { Transaction } from 'modules/transactions';
+import transactionReducer from 'modules/transactions';
+import { getTransaction, getTransactionContribution } from 'selectors/transactions';
 
-// inject reducers that might not have been originally there
 injectAsyncReducers({
-  transactions: transactionReducer
+  transactions: transactionReducer,
 });
 
-const BudgetItemContainer = () => (
-  <section>
-    <BudgetItem />
-  </section>
-);
+const mapStateToProps = (state, props) => {
+  const transaction: Transaction = getTransaction(state, props.match.params.id);
+  const contribution = getTransactionContribution(state, props.match.params.id);
 
-export default BudgetItemContainer;
+  return {
+    transaction: transaction,
+    contribution: contribution,
+  };
+};
+
+export default connect(mapStateToProps)(BudgetItem);

--- a/app/containers/BudgetItem/index.js
+++ b/app/containers/BudgetItem/index.js
@@ -1,0 +1,18 @@
+// @flow
+import * as React from 'react';
+import transactionReducer from 'modules/transactions';
+import { injectAsyncReducers } from 'store';
+import BudgetItem from 'components/BudgetItem';
+
+// inject reducers that might not have been originally there
+injectAsyncReducers({
+  transactions: transactionReducer
+});
+
+const BudgetItemContainer = () => (
+  <section>
+    <BudgetItem />
+  </section>
+);
+
+export default BudgetItemContainer;

--- a/app/containers/BudgetItem/index.js
+++ b/app/containers/BudgetItem/index.js
@@ -1,4 +1,5 @@
 // @flow
+import { withRouter } from 'react-router-dom';
 import { injectAsyncReducers } from 'store';
 import { connect } from 'react-redux';
 import BudgetItem from 'components/BudgetItem';
@@ -8,6 +9,10 @@ import { getTransaction, getTransactionContribution } from 'selectors/transactio
 
 injectAsyncReducers({
   transactions: transactionReducer,
+});
+
+const mapDispatchToProps = (dispatch, props) => ({
+  goBackHandler: props.history.goBack,
 });
 
 const mapStateToProps = (state, props) => {
@@ -20,4 +25,4 @@ const mapStateToProps = (state, props) => {
   };
 };
 
-export default connect(mapStateToProps)(BudgetItem);
+export default connect(mapStateToProps, mapDispatchToProps)(BudgetItem);

--- a/app/containers/BudgetItem/index.js
+++ b/app/containers/BudgetItem/index.js
@@ -1,5 +1,4 @@
 // @flow
-import * as React from 'react';
 import { injectAsyncReducers } from 'store';
 import { connect } from 'react-redux';
 import BudgetItem from 'components/BudgetItem';

--- a/app/containers/BudgetItem/index.js
+++ b/app/containers/BudgetItem/index.js
@@ -11,6 +11,7 @@ injectAsyncReducers({
   transactions: transactionReducer,
 });
 
+//pass the history handler to the component so the button will be able to call it
 const mapDispatchToProps = (dispatch, props) => ({
   goBackHandler: props.history.goBack,
 });

--- a/app/routes/BudgetItem/index.js
+++ b/app/routes/BudgetItem/index.js
@@ -1,0 +1,13 @@
+// @flow
+import React, { Component } from 'react';
+import Chunk from 'components/Chunk';
+
+const loadBudgetItemContainer = () => import('containers/BudgetItem' /* webpackChunkName: "transaction" */);
+
+class BudgetItem extends Component<{}> {
+  render() {
+    return <Chunk load={loadBudgetItemContainer} />;
+  }
+}
+
+export default BudgetItem;

--- a/app/routes/BudgetItem/index.js
+++ b/app/routes/BudgetItem/index.js
@@ -6,7 +6,7 @@ const loadBudgetItemContainer = () => import('containers/BudgetItem' /* webpackC
 
 class BudgetItem extends Component<{}> {
   render() {
-    return <Chunk load={loadBudgetItemContainer} />;
+    return <Chunk load={loadBudgetItemContainer} {...this.props} />;
   }
 }
 

--- a/app/selectors/transactions.js
+++ b/app/selectors/transactions.js
@@ -39,6 +39,10 @@ const applyCategoryName = (transactions: TransactionSummary[], categories) =>
 
 export const getTransactions = (state: State): Transaction[] => state.transactions || [];
 
+export const getTransaction = (state: State, id: number) => {
+  return state.transactions.find(t => t.id === Number(id));
+}
+
 const getInflowTransactions = createSelector([getTransactions], transactions =>
   transactions.filter(item => item.value > 0)
 );
@@ -55,6 +59,25 @@ export const getInflowBalance = createSelector([getInflowTransactions], transact
 
 export const getOutflowBalance = createSelector([getOutflowTransactions], transactions =>
   totalTransactions(transactions)
+);
+
+export const getTransactionContribution = createSelector([getTransaction, getInflowBalance, getOutflowBalance],
+  (transaction, inflowBalance, outflowBalance) => {
+    let percent = 0;
+
+    // if transaction value is negative, then calulate how much it represents of the negative total
+    percent =
+    transaction.value < 0
+      ? parseFloat((100 * transaction.value / outflowBalance).toFixed(2))
+      : parseFloat((100 * transaction.value / inflowBalance).toFixed(2));
+
+    const flowTotal = transaction.value < 0 ? outflowBalance : inflowBalance;
+
+    return {
+      flowTotal: flowTotal,
+      percent: percent,
+    }
+  }
 );
 
 export const getFormattedBalance = createSelector([getBalance], amount => formatAmount(amount, false));

--- a/app/utils/formatAmount.js
+++ b/app/utils/formatAmount.js
@@ -6,7 +6,7 @@ export type FormattedAmount = {
   isPercent: boolean,
 };
 
-export default function formatAmount(amount: number, showSign: boolean = true, showPercent: boolean): FormattedAmount {
+export default function formatAmount(amount: number, showSign: boolean = true, showPercent: boolean = false): FormattedAmount {
   const isNegative = amount < 0;
   let formatValue = Math.abs(amount);
 

--- a/app/utils/formatAmount.js
+++ b/app/utils/formatAmount.js
@@ -3,17 +3,22 @@
 export type FormattedAmount = {
   text: string,
   isNegative: boolean,
+  isPercent: boolean,
 };
 
-export default function formatAmount(amount: number, showSign: boolean = true): FormattedAmount {
+export default function formatAmount(amount: number, showSign: boolean = true, showPercent: boolean): FormattedAmount {
   const isNegative = amount < 0;
-  const formatValue = Math.abs(amount).toLocaleString('en-us', {
-    style: 'currency',
-    currency: 'USD',
-  });
+  let formatValue = Math.abs(amount);
+
+  if(!showPercent) {
+    formatValue = formatValue.toLocaleString('en-us', {
+      style: 'currency',
+      currency: 'USD',
+    });
+  }
 
   return {
-    text: `${isNegative && showSign ? '-' : ''}${formatValue}`,
+    text: `${isNegative && showSign ? '-' : ''}${formatValue}${showPercent ? '%' : ''}`,
     isNegative,
   };
 }


### PR DESCRIPTION
## Proposed Changes

Given that I have added at least one item to the budgeting grid 
When I click on that item 
Then I want to see a new page with a title corresponding to the item details 
And route should be dynamic with item ID in it 
And a subtitle under title should show percentage with red minus sign showing outflow, green plus sign for inflow 
And a pie chart showing how much of the entire budget this item is contributing with should be on that page 
And no other items from the budget should be on that pie chart 
And there should be a back button to return back to the previous route 
And the view should be mobile and desktop compatible 

## Screenshot

<img width="743" alt="screen shot 2017-11-15 at 23 49 57" src="https://user-images.githubusercontent.com/8809855/32869763-d4e30f7a-ca5f-11e7-950d-d3e35d580f6d.png">

## Checklist

* [x] Feature developed
* [x] Created/updated unit tests
* [x] Comments in code
* [ ] Documentation written
