### PR TITLE
See total budget an item is contributing with

### DIFF
--- a/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<tr>
+<tr
+  onClick={[Function]}
+>
   <td>
     <div
       className="cellLabel"

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -3,21 +3,27 @@ import * as React from 'react';
 import formatAmount from 'utils/formatAmount';
 import type { Transaction } from 'modules/transactions';
 import type { Categories } from 'modules/categories';
+import { Link } from 'react-router-dom';
 import styles from './style.scss';
 
 type BudgetGridRowProps = {
   transaction: Transaction,
   categories: Categories,
+  linkToItemDetails: Function,
 };
 
-const BudgetGridRow = ({ transaction, categories }: BudgetGridRowProps) => {
+const BudgetGridRow = ({ transaction, categories, linkToItemDetails }: BudgetGridRowProps) => {
   const amount = formatAmount(transaction.value);
   const amountCls = amount.isNegative ? styles.neg : styles.pos;
   const { id, categoryId, description } = transaction;
   const category = categories[categoryId];
+  const url = `/reports/item-details/${id}`
 
   return (
-    <tr key={id}>
+    <tr key={id}
+    onClick={() => {
+      linkToItemDetails(id);
+    }}>
       <td>
         <div className={styles.cellLabel}>Category</div>
         <div className={styles.cellContent}>{category}</div>

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -3,7 +3,6 @@ import * as React from 'react';
 import formatAmount from 'utils/formatAmount';
 import type { Transaction } from 'modules/transactions';
 import type { Categories } from 'modules/categories';
-import { Link } from 'react-router-dom';
 import styles from './style.scss';
 
 type BudgetGridRowProps = {
@@ -17,13 +16,14 @@ const BudgetGridRow = ({ transaction, categories, linkToItemDetails }: BudgetGri
   const amountCls = amount.isNegative ? styles.neg : styles.pos;
   const { id, categoryId, description } = transaction;
   const category = categories[categoryId];
-  const url = `/reports/item-details/${id}`
 
   return (
-    <tr key={id}
-    onClick={() => {
-      linkToItemDetails(id);
-    }}>
+    <tr
+      key={id}
+      onClick={() => {
+        linkToItemDetails(id);
+      }}
+    >
       <td>
         <div className={styles.cellLabel}>Category</div>
         <div className={styles.cellContent}>{category}</div>

--- a/app/components/BudgetGridRow/style.scss
+++ b/app/components/BudgetGridRow/style.scss
@@ -12,6 +12,7 @@
 
 .cellContent {
   flex: 1;
+  cursor: pointer;
 }
 
 .neg {

--- a/app/components/DonutChart/index.js
+++ b/app/components/DonutChart/index.js
@@ -19,6 +19,7 @@ type DonutChartProps = {
   color: Function,
   height: number,
   innerRatio: number,
+  isPie: boolean
 };
 
 class DonutChart extends React.Component<DonutChartProps> {
@@ -44,9 +45,10 @@ class DonutChart extends React.Component<DonutChartProps> {
   }
 
   getPathArc = () => {
-    const { height, innerRatio } = this.props;
+    const { height, innerRatio, isPie } = this.props;
+    let innerRadius = (isPie ? 0 : height / innerRatio);
     return arc()
-      .innerRadius(height / innerRatio)
+      .innerRadius(innerRadius)
       .outerRadius(height / 2);
   };
 
@@ -61,7 +63,7 @@ class DonutChart extends React.Component<DonutChartProps> {
     const { data, dataValue, color, height } = this.props;
 
     this.chart = pie()
-      .value(d => d[dataValue])
+      .value(d => Math.abs(d[dataValue]))
       .sort(null);
     this.outerRadius = height / 2;
     this.pathArc = this.getPathArc();

--- a/app/components/DonutChart/index.js
+++ b/app/components/DonutChart/index.js
@@ -19,7 +19,7 @@ type DonutChartProps = {
   color: Function,
   height: number,
   innerRatio: number,
-  isPie: boolean
+  isPie: boolean,
 };
 
 class DonutChart extends React.Component<DonutChartProps> {
@@ -46,7 +46,7 @@ class DonutChart extends React.Component<DonutChartProps> {
 
   getPathArc = () => {
     const { height, innerRatio, isPie } = this.props;
-    let innerRadius = (isPie ? 0 : height / innerRatio);
+    const innerRadius = isPie ? 0 : height / innerRatio;
     return arc()
       .innerRadius(innerRadius)
       .outerRadius(height / 2);

--- a/app/components/ReportsPanel/index.js
+++ b/app/components/ReportsPanel/index.js
@@ -6,6 +6,7 @@ import categoryReducer from 'modules/categories';
 import { injectAsyncReducers } from 'store';
 import InflowOutflow from 'containers/InflowOutflow';
 import Spending from 'containers/Spending';
+import ItemDetails from 'containers/ItemDetails';
 import ReportsTabbar from './ReportsTabbar';
 
 // inject reducers that might not have been originally there
@@ -21,6 +22,7 @@ const ReportsPanel = () => (
     <Switch>
       <Route path="/reports/inflow-outflow" component={InflowOutflow} />
       <Route path="/reports/spending" component={Spending} />
+      <Route path="/reports/item-details/:id" component={ItemDetails} />
       <Redirect to="/reports/inflow-outflow" />
     </Switch>
   </section>

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -7,6 +7,7 @@ import AppError from 'components/AppError';
 import Header from 'components/Header';
 import Budget from 'routes/Budget';
 import Reports from 'routes/Reports';
+import ItemDetails from 'routes/ItemDetails';
 import './style.scss';
 
 const App = () => (
@@ -17,6 +18,7 @@ const App = () => (
       <Switch>
         <Route path="/budget" component={Budget} />
         <Route path="/reports" component={Reports} />
+        <Route path="/reports/item-details/:id" component={ItemDetails} />
         <Redirect to="/budget" />
       </Switch>
     </main>

--- a/app/containers/BudgetGrid/index.js
+++ b/app/containers/BudgetGrid/index.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
 import { getTransactions } from 'selectors/transactions';
 import { getCategories } from 'selectors/categories';
 import EntryFormRow from 'containers/EntryFormRow';
@@ -19,6 +20,17 @@ export class BudgetGrid extends React.Component<BudgetGridProps> {
     categories: {},
   };
 
+  constructor(props) {
+    super(props);
+    this.linkToItemDetails = this.linkToItemDetails.bind(this);
+  }
+
+  linkToItemDetails(id) {
+    const { history } = this.props;
+    const path = `/reports/item-details/${id}`;
+    history.push(path);
+  }
+
   render() {
     const { transactions, categories } = this.props;
 
@@ -33,7 +45,11 @@ export class BudgetGrid extends React.Component<BudgetGridProps> {
         </thead>
         <tbody>
           {transactions.map((transaction: Transaction): React.Element<any> => (
-            <BudgetGridRow key={transaction.id} transaction={transaction} categories={categories} />
+            <BudgetGridRow 
+            key={transaction.id} 
+            transaction={transaction} 
+            categories={categories} 
+            linkToItemDetails={this.linkToItemDetails} />
           ))}
         </tbody>
         <tfoot>
@@ -49,4 +65,4 @@ const mapStateToProps = state => ({
   categories: getCategories(state),
 });
 
-export default connect(mapStateToProps)(BudgetGrid);
+export default connect(mapStateToProps)(withRouter(BudgetGrid));

--- a/app/containers/BudgetGrid/index.js
+++ b/app/containers/BudgetGrid/index.js
@@ -45,11 +45,12 @@ export class BudgetGrid extends React.Component<BudgetGridProps> {
         </thead>
         <tbody>
           {transactions.map((transaction: Transaction): React.Element<any> => (
-            <BudgetGridRow 
-            key={transaction.id} 
-            transaction={transaction} 
-            categories={categories} 
-            linkToItemDetails={this.linkToItemDetails} />
+            <BudgetGridRow
+              key={transaction.id}
+              transaction={transaction}
+              categories={categories}
+              linkToItemDetails={this.linkToItemDetails}
+            />
           ))}
         </tbody>
         <tfoot>

--- a/app/containers/ItemDetails/index.js
+++ b/app/containers/ItemDetails/index.js
@@ -10,22 +10,24 @@ import DonutChart from 'components/DonutChart';
 import styles from './style.scss';
 
 type ItemDetailsProps = {
-  data: TransactionContribution
+  data: TransactionContribution,
 };
 
-class ItemDetails extends React.Component <ItemDetailsProps> {
+class ItemDetails extends React.Component<ItemDetailsProps> {
   render() {
     const { data } = this.props;
+    const isPie = true;
     const chartData = [
       {
         id: data.id,
         value: data.value,
-        description: data.description
-      }, {
+        description: data.description,
+      },
+      {
         id: data.id + 1,
         value: data.totalBudget,
-        description: 'Total Budget'
-      }
+        description: 'Total Budget',
+      },
     ];
 
     return (
@@ -33,24 +35,17 @@ class ItemDetails extends React.Component <ItemDetailsProps> {
         <Link to="/budget">Back to Budget</Link>
         <h2>{data.description}</h2>
         <h3>
-          {data.value < 0
-            ? <span className={styles.red}>-</span>
-            : <span className={styles.green}>+</span>}
+          {data.value < 0 ? <span className={styles.red}>-</span> : <span className={styles.green}>+</span>}
           {Math.abs(data.percentage)}%
         </h3>
-        <DonutChart
-          key={data.id}
-          isPie={true}
-          data={chartData}
-          dataLabel="description"
-          dataKey="id"/>
+        <DonutChart key={data.id} isPie={isPie} data={chartData} dataLabel="description" dataKey="id" />
       </div>
     );
   }
 }
 
 const mapStateToProps = (state, props) => ({
-  data: getTransactionContribution(state, parseInt(props.match.params.id, 10))
+  data: getTransactionContribution(state, parseInt(props.match.params.id, 10)),
 });
 
 export default connect(mapStateToProps)(ItemDetails);

--- a/app/containers/ItemDetails/index.js
+++ b/app/containers/ItemDetails/index.js
@@ -1,0 +1,56 @@
+// @flow
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+import type { TransactionContribution } from 'selectors/transactions';
+import { getTransactionContribution } from 'selectors/transactions';
+
+import DonutChart from 'components/DonutChart';
+
+import styles from './style.scss';
+
+type ItemDetailsProps = {
+  data: TransactionContribution
+};
+
+class ItemDetails extends React.Component <ItemDetailsProps> {
+  render() {
+    const { data } = this.props;
+    const chartData = [
+      {
+        id: data.id,
+        value: data.value,
+        description: data.description
+      }, {
+        id: data.id + 1,
+        value: data.totalBudget,
+        description: 'Total Budget'
+      }
+    ];
+
+    return (
+      <div className={styles.itemDetails}>
+        <Link to="/budget">Back to Budget</Link>
+        <h2>{data.description}</h2>
+        <h3>
+          {data.value < 0
+            ? <span className={styles.red}>-</span>
+            : <span className={styles.green}>+</span>}
+          {Math.abs(data.percentage)}%
+        </h3>
+        <DonutChart
+          key={data.id}
+          isPie={true}
+          data={chartData}
+          dataLabel="description"
+          dataKey="id"/>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = (state, props) => ({
+  data: getTransactionContribution(state, parseInt(props.match.params.id, 10))
+});
+
+export default connect(mapStateToProps)(ItemDetails);

--- a/app/containers/ItemDetails/index.js
+++ b/app/containers/ItemDetails/index.js
@@ -17,16 +17,17 @@ class ItemDetails extends React.Component<ItemDetailsProps> {
   render() {
     const { data } = this.props;
     const isPie = true;
+    const value = Math.abs(data.value);
     const chartData = [
       {
         id: data.id,
-        value: data.value,
+        value: value,
         description: data.description,
       },
       {
         id: data.id + 1,
-        value: data.totalBudget,
-        description: 'Total Budget',
+        value: data.totalBudget - value,
+        description: 'Remaining Budget',
       },
     ];
 

--- a/app/containers/ItemDetails/style.scss
+++ b/app/containers/ItemDetails/style.scss
@@ -1,0 +1,17 @@
+@import 'theme/variables';
+
+.itemDetails {
+  h2, h3 {
+    text-align: center;
+  }
+  display: flex;
+  flex-direction: column;
+}
+
+.red {
+  color: red;
+}
+
+.green {
+  color: green;
+}

--- a/app/routes/ItemDetails/index.js
+++ b/app/routes/ItemDetails/index.js
@@ -5,9 +5,9 @@ import Chunk from 'components/Chunk';
 const loadItemDetailsContainer = () => import('containers/ItemDetails' /* webpackChunkName: "itemDetails" */);
 
 class ItemDetails extends Component<{}> {
-    render() {
-        return <Chunk load={loadItemDetailsContainer} />;
-    }
+  render() {
+    return <Chunk load={loadItemDetailsContainer} />;
+  }
 }
 
 export default ItemDetails;

--- a/app/routes/ItemDetails/index.js
+++ b/app/routes/ItemDetails/index.js
@@ -1,0 +1,13 @@
+// @flow
+import React, { Component } from 'react';
+import Chunk from 'components/Chunk';
+
+const loadItemDetailsContainer = () => import('containers/ItemDetails' /* webpackChunkName: "itemDetails" */);
+
+class ItemDetails extends Component<{}> {
+    render() {
+        return <Chunk load={loadItemDetailsContainer} />;
+    }
+}
+
+export default ItemDetails;

--- a/app/selectors/transactions.js
+++ b/app/selectors/transactions.js
@@ -94,7 +94,7 @@ export const getTransactionContribution = createSelector(
   (transaction, inflowBalance) => {
     let percentage = 0;
     // Total budget should be the amount in hand
-    let totalBudget = inflowBalance;
+    const totalBudget = inflowBalance;
     // Percentage of total budget this item is contributing with
     percentage = parseFloat((100 * transaction.value / totalBudget).toFixed(2));
 

--- a/app/selectors/transactions.js
+++ b/app/selectors/transactions.js
@@ -12,6 +12,14 @@ export type TransactionSummary = {
   category?: string,
 };
 
+export type TransactionContribution = {
+  id: number,
+  value: number,
+  description: string,
+  percentage: number,
+  totalBudget: number,
+};
+
 function totalTransactions(transactions: Transaction[]): number {
   return transactions.reduce((total, item) => total + parseFloat(item.value), 0);
 }
@@ -38,6 +46,8 @@ const applyCategoryName = (transactions: TransactionSummary[], categories) =>
   });
 
 export const getTransactions = (state: State): Transaction[] => state.transactions || [];
+export const getTransaction = (state: State, id: number): Transaction =>
+  state.transactions.find(iterator => iterator.id === id) || {};
 
 const getInflowTransactions = createSelector([getTransactions], transactions =>
   transactions.filter(item => item.value > 0)
@@ -77,4 +87,23 @@ export const getOutflowByCategoryName = createSelector(getOutflowByCategory, get
 
 export const getInflowByCategoryName = createSelector(getInflowByCategory, getCategories, (trans, cat) =>
   applyCategoryName(trans, cat)
+);
+
+export const getTransactionContribution = createSelector(
+  [getTransaction, getInflowBalance],
+  (transaction, inflowBalance) => {
+    let percentage = 0;
+    // Total budget should be the amount in hand
+    let totalBudget = inflowBalance;
+    // Percentage of total budget this item is contributing with
+    percentage = parseFloat((100 * transaction.value / totalBudget).toFixed(2));
+
+    return {
+      id: transaction.id,
+      value: transaction.value,
+      description: transaction.description,
+      percentage,
+      totalBudget,
+    };
+  }
 );


### PR DESCRIPTION

## Screenshot

<img width="1917" alt="Modus Feature" src="https://user-images.githubusercontent.com/3376555/33034601-34ca97a2-cddd-11e7-9be6-61a50dcf9fa2.png">


## Checklist
 
* [x] Feature developed
* [x] Create new page with a title corresponding to the item details user clicked on the budget grid
* [x] The new page route should be dynamic with item ID in it
* [x] Display subtitle under title as a percentage with red minus sign showing outflow, green plus sign for inflow
* [x] Draw a pie chart showing how much of the entire budget this item is contributing with
* [x] No other items from the budget should be on that pie chart
* [x] Put a back button to return back to the previous route
* [x] Make the view mobile and desktop compatible
* [x] Feature developed
* [x] Created/updated unit tests
* [x] Comments in code
* [x] Documentation written
