### PR TITLE
Implement BudgetItem view at `/budget/:id`

### DIFF
--- a/.exrc
+++ b/.exrc
@@ -1,0 +1,3 @@
+
+set colorcolumn=120
+autocmd FileType javascript set formatprg=prettier\ --trailing-comma\ es5\ --print-width\ 120\ --single-quote\ --stdin

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage
 .idea
 /.cache-loader
 /.vscode
+tags

--- a/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
@@ -1,7 +1,64 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders \`cursor: pointer\` when onClick is provided 1`] = `
+<tr
+  onClick={[Function]}
+  style={
+    Object {
+      "cursor": "pointer",
+    }
+  }
+>
+  <td>
+    <div
+      className="cellLabel"
+    >
+      Category
+    </div>
+    <div
+      className="cellContent"
+    >
+      Groceries
+    </div>
+  </td>
+  <td>
+    <div
+      className="cellLabel"
+    >
+      Description
+    </div>
+    <div
+      className="cellContent"
+    >
+      Trader Joe's food
+    </div>
+  </td>
+  <td
+    className="neg"
+  >
+    <div
+      className="cellLabel"
+    >
+      Amount
+    </div>
+    <div
+      className="cellContent"
+    >
+      -$423.34
+    </div>
+  </td>
+</tr>
+`;
+
 exports[`renders correctly 1`] = `
-<tr>
+<tr
+  onClick={[Function]}
+  style={
+    Object {
+      "cursor": "inherit",
+    }
+  }
+>
   <td>
     <div
       className="cellLabel"

--- a/app/components/BudgetGridRow/__tests__/index-test.js
+++ b/app/components/BudgetGridRow/__tests__/index-test.js
@@ -2,19 +2,26 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import BudgetGridRow from 'components/BudgetGridRow';
 
+const mockTransaction = {
+  id: 1,
+  description: "Trader Joe's food",
+  value: -423.34,
+  categoryId: 1,
+};
+
+const mockCategories = {
+  1: 'Groceries',
+  2: 'School',
+};
+
 it('renders correctly', () => {
-  const mockTransaction = {
-    id: 1,
-    description: "Trader Joe's food",
-    value: -423.34,
-    categoryId: 1,
-  };
-
-  const mockCategories = {
-    1: 'Groceries',
-    2: 'School',
-  };
-
   const tree = renderer.create(<BudgetGridRow transaction={mockTransaction} categories={mockCategories} />).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('renders `cursor: pointer` when onClick is provided', () => {
+  const tree = renderer
+    .create(<BudgetGridRow transaction={mockTransaction} categories={mockCategories} onClick={() => undefined} />)
+    .toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -8,16 +8,17 @@ import styles from './style.scss';
 type BudgetGridRowProps = {
   transaction: Transaction,
   categories: Categories,
+  onClick?: ?(number) => void,
 };
 
-const BudgetGridRow = ({ transaction, categories }: BudgetGridRowProps) => {
+const BudgetGridRow = ({ transaction, categories, onClick }: BudgetGridRowProps) => {
   const amount = formatAmount(transaction.value);
   const amountCls = amount.isNegative ? styles.neg : styles.pos;
   const { id, categoryId, description } = transaction;
   const category = categories[categoryId];
 
   return (
-    <tr key={id}>
+    <tr key={id} onClick={() => onClick && onClick(id)} style={{ cursor: onClick ? 'pointer' : 'inherit' }}>
       <td>
         <div className={styles.cellLabel}>Category</div>
         <div className={styles.cellContent}>{category}</div>
@@ -32,6 +33,10 @@ const BudgetGridRow = ({ transaction, categories }: BudgetGridRowProps) => {
       </td>
     </tr>
   );
+};
+
+BudgetGridRow.defaultProps = {
+  onClick: null,
 };
 
 export default BudgetGridRow;

--- a/app/components/DonutChart/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/DonutChart/__tests__/__snapshots__/index-test.js.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`could hide <Legend/> 1`] = `
+<div
+  className="donutChart"
+>
+  <div
+    height={316}
+    padding={8}
+    transform="translate(150,150)"
+    width={316}
+  />
+</div>
+`;
+
 exports[`renders correctly 1`] = `
 <div
   className="donutChart"

--- a/app/components/DonutChart/__tests__/index-test.js
+++ b/app/components/DonutChart/__tests__/index-test.js
@@ -11,3 +11,8 @@ it('renders correctly', () => {
   const tree = renderer.create(<DonutChart dataLabel="test" dataKey="test" data={[]} />).toJSON();
   expect(tree).toMatchSnapshot();
 });
+
+it('could hide <Legend/>', () => {
+  const tree = renderer.create(<DonutChart dataLabel="test" dataKey="test" data={[]} showLegend={false} />).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/components/DonutChart/index.js
+++ b/app/components/DonutChart/index.js
@@ -13,12 +13,13 @@ const randomScheme = shuffle(schemeCategory20);
 
 type DonutChartProps = {
   data: TransactionSummary[],
-  dataLabel: string,
+  dataLabel?: string,
   dataKey: string,
   dataValue: string,
   color: Function,
   height: number,
   innerRatio: number,
+  showLegend: boolean,
 };
 
 class DonutChart extends React.Component<DonutChartProps> {
@@ -27,6 +28,8 @@ class DonutChart extends React.Component<DonutChartProps> {
     height: 300,
     innerRatio: 4,
     dataValue: 'value',
+    dataKey: 'categoryId', // this is specified in type declaration
+    showLegend: true,
   };
 
   componentWillMount() {
@@ -46,7 +49,7 @@ class DonutChart extends React.Component<DonutChartProps> {
   getPathArc = () => {
     const { height, innerRatio } = this.props;
     return arc()
-      .innerRadius(height / innerRatio)
+      .innerRadius(innerRatio === 0 ? 0 : height / innerRatio)
       .outerRadius(height / 2);
   };
 
@@ -58,19 +61,19 @@ class DonutChart extends React.Component<DonutChartProps> {
   chartPadding = 8;
 
   updateChartVariables = () => {
-    const { data, dataValue, color, height } = this.props;
+    const { data, dataValue, dataKey, color, height } = this.props;
 
     this.chart = pie()
       .value(d => d[dataValue])
       .sort(null);
     this.outerRadius = height / 2;
     this.pathArc = this.getPathArc();
-    this.colorFn = color.domain && color.domain([0, data.length]);
+    this.colorFn = color.domain && color.domain(data.map(d => d[dataKey]));
     this.boxLength = height + this.chartPadding * 2;
   };
 
   render() {
-    const { data, dataLabel, dataValue, dataKey } = this.props;
+    const { data, dataLabel, dataValue, dataKey, showLegend } = this.props;
     const { outerRadius, pathArc, colorFn, boxLength, chartPadding } = this;
 
     return (
@@ -86,7 +89,7 @@ class DonutChart extends React.Component<DonutChartProps> {
           ))}
         </Chart>
 
-        <Legend color={colorFn} {...{ data, dataValue, dataLabel, dataKey }} />
+        {showLegend && <Legend color={colorFn} {...{ data, dataValue, dataLabel, dataKey }} />}
       </div>
     );
   }

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -6,6 +6,7 @@ import ErrorBoundary from 'components/ErrorBoundary';
 import AppError from 'components/AppError';
 import Header from 'components/Header';
 import Budget from 'routes/Budget';
+import BudgetItem from 'routes/BudgetItem';
 import Reports from 'routes/Reports';
 import './style.scss';
 
@@ -15,6 +16,7 @@ const App = () => (
       <Header />
 
       <Switch>
+        <Route path="/budget/:id" component={BudgetItem} />
         <Route path="/budget" component={Budget} />
         <Route path="/reports" component={Reports} />
         <Redirect to="/budget" />

--- a/app/containers/Balance/index.js
+++ b/app/containers/Balance/index.js
@@ -21,7 +21,7 @@ class Balance extends React.Component<BalanceProps> {
       <BalanceRow>
         <BalanceItem amount={inflow} title="Total Inflow" />
         <BalanceItem amount={outflow} title="Total Outflow" prefix="-" />
-        <BalanceItem amount={balance} title="Working Balance" colorize={false} prefix="=" />
+        <BalanceItem amount={balance} title="Working Balance" colorize prefix="=" />
       </BalanceRow>
     );
   }

--- a/app/containers/Budget/index.js
+++ b/app/containers/Budget/index.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import { type RouterHistory } from 'react-router';
 import transactionReducer from 'modules/transactions';
 import categoryReducer from 'modules/categories';
 import { injectAsyncReducers } from 'store';
@@ -12,9 +13,9 @@ injectAsyncReducers({
   categories: categoryReducer,
 });
 
-const BudgetContainer = () => (
+const BudgetContainer = ({ history }: { history: RouterHistory }) => (
   <section>
-    <BudgetGrid />
+    <BudgetGrid onRowClick={id => history.push(`/budget/${id}`)} />
     <Balance />
   </section>
 );

--- a/app/containers/BudgetGrid/index.js
+++ b/app/containers/BudgetGrid/index.js
@@ -11,16 +11,18 @@ import styles from './style.scss';
 type BudgetGridProps = {
   transactions: Transaction[],
   categories: Object,
+  onRowClick?: number => void,
 };
 
 export class BudgetGrid extends React.Component<BudgetGridProps> {
   static defaultProps = {
     transactions: [],
     categories: {},
+    onRowClick: null,
   };
 
   render() {
-    const { transactions, categories } = this.props;
+    const { transactions, categories, onRowClick } = this.props;
 
     return (
       <table className={styles.budgetGrid}>
@@ -33,7 +35,12 @@ export class BudgetGrid extends React.Component<BudgetGridProps> {
         </thead>
         <tbody>
           {transactions.map((transaction: Transaction): React.Element<any> => (
-            <BudgetGridRow key={transaction.id} transaction={transaction} categories={categories} />
+            <BudgetGridRow
+              key={transaction.id}
+              transaction={transaction}
+              categories={categories}
+              onClick={onRowClick}
+            />
           ))}
         </tbody>
         <tfoot>

--- a/app/containers/BudgetItem/__tests__/__snapshots__/index-test.js.snap
+++ b/app/containers/BudgetItem/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,99 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders inflow transaction 1`] = `
+<section>
+  <div
+    className="RRLink"
+    to=".."
+  >
+    <button>
+      Back
+    </button>
+  </div>
+  <h3>
+    test
+  </h3>
+  <h4>
+    <span
+      className="budgetItemPos"
+    >
+      20
+      %
+    </span>
+  </h4>
+  <DonutChart
+    color={[Function]}
+    data={
+      Array [
+        Object {
+          "categoryId": "0",
+          "value": 100,
+        },
+        Object {
+          "categoryId": "1",
+          "value": 400,
+        },
+      ]
+    }
+    innerRatio={0}
+    showLegend={false}
+  />
+</section>
+`;
+
+exports[`renders non existent transaction 1`] = `
+<section>
+  <div
+    className="RRLink"
+    to=".."
+  >
+    <button>
+      Back
+    </button>
+  </div>
+  <h3>
+    Not Found
+  </h3>
+</section>
+`;
+
+exports[`renders outflow transaction 1`] = `
+<section>
+  <div
+    className="RRLink"
+    to=".."
+  >
+    <button>
+      Back
+    </button>
+  </div>
+  <h3>
+    test
+  </h3>
+  <h4>
+    <span
+      className="budgetItemNeg"
+    >
+      20
+      %
+    </span>
+  </h4>
+  <DonutChart
+    color={[Function]}
+    data={
+      Array [
+        Object {
+          "categoryId": "0",
+          "value": 100,
+        },
+        Object {
+          "categoryId": "1",
+          "value": 400,
+        },
+      ]
+    }
+    innerRatio={0}
+    showLegend={false}
+  />
+</section>
+`;

--- a/app/containers/BudgetItem/__tests__/index-test.js
+++ b/app/containers/BudgetItem/__tests__/index-test.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { MaybeBudgetItem as BudgetItem, mapStateToProps } from '../index';
+
+jest.mock('components/DonutChart', () => 'DonutChart');
+jest.mock('react-router-dom', () => ({ Link: props => <div className="RRLink" {...props} /> }));
+
+it('renders inflow transaction', () => {
+  const transaction = { value: 100, description: 'test' };
+  const total = 500;
+  const tree = renderer.create(<BudgetItem item={{ transaction, total }} />).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('renders outflow transaction', () => {
+  const transaction = { value: -100, description: 'test' };
+  const total = -500;
+  const tree = renderer.create(<BudgetItem item={{ transaction, total }} />).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('renders non existent transaction', () => {
+  const tree = renderer.create(<BudgetItem item={null} />).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+const t1 = { id: 1, value: 100, description: 'test #1' };
+const t2 = { id: 2, value: -400, description: 'test #2' };
+const t3 = { id: 3, value: 400, description: 'test #2' };
+const state = { transactions: [t1, t2, t3] };
+
+it('takes the proper transaction by id', () => {
+  expect(mapStateToProps(state, { id: '1' })).toEqual({
+    item: { transaction: t1, total: t1.value + t3.value },
+  });
+});
+
+it('uses null if transaction is not found', () => {
+  expect(mapStateToProps(state, { id: '4' })).toEqual({
+    item: null,
+  });
+
+  expect(mapStateToProps(state, { id: '1some' })).toEqual({
+    item: null,
+  });
+
+  expect(mapStateToProps(state, { id: 'some' })).toEqual({
+    item: null,
+  });
+});

--- a/app/containers/BudgetItem/index.js
+++ b/app/containers/BudgetItem/index.js
@@ -1,0 +1,74 @@
+// @flow
+
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { rgb, scaleOrdinal } from 'd3';
+import { Link } from 'react-router-dom';
+import { getTransactions, getInflowBalance, getOutflowBalance } from 'selectors/transactions';
+import transactionReducer, { type Transaction } from 'modules/transactions';
+import { type State } from 'modules/rootReducer';
+import DonutChart from 'components/DonutChart';
+import { injectAsyncReducers } from 'store';
+import styles from './style.scss';
+
+// inject reducers that might not have been originally there
+injectAsyncReducers({
+  transactions: transactionReducer,
+});
+
+type BudgetItemType = {
+  transaction: Transaction,
+  total: number,
+};
+
+export const MaybeBudgetItem = ({ item }: { item: ?BudgetItemType }) =>
+  item === null || item === undefined ? (
+    <section>
+      <BackButton />
+      <h3>Not Found</h3>
+    </section>
+  ) : (
+    <BudgetItem {...item} />
+  );
+
+const BudgetItem = ({ transaction: { description, value }, total }: BudgetItemType) => (
+  <section>
+    <BackButton />
+    <h3>{description}</h3>
+    <h4>
+      <span className={value > 0 ? styles.budgetItemPos : styles.budgetItemNeg}>
+        {Math.round(value * 100 / total)}%
+      </span>
+    </h4>
+    <PieChart share={Math.abs(value)} total={Math.abs(total)} color={value > 0 ? styles.pos : styles.neg} />
+  </section>
+);
+
+const PieChart = ({ share, total, color }: { share: number, total: number, color: string }) => (
+  <DonutChart
+    data={[{ value: share, categoryId: '0' }, { value: total - share, categoryId: '1' }]}
+    color={scaleOrdinal([
+      color,
+      rgb(color)
+        .brighter(3.5)
+        .toString(),
+    ])}
+    innerRatio={0}
+    showLegend={false}
+  />
+);
+
+const BackButton = () => (
+  <Link to="..">
+    <button>Back</button>
+  </Link>
+);
+
+export const mapStateToProps = (state: State, { id }: { id: string }) => {
+  const transaction = /^\d+$/.test(id) ? getTransactions(state).filter(t => t.id === parseInt(id, 10))[0] : undefined;
+  return transaction === undefined
+    ? { item: null }
+    : { item: { transaction, total: transaction.value > 0 ? getInflowBalance(state) : getOutflowBalance(state) } };
+};
+
+export default connect(mapStateToProps)(MaybeBudgetItem);

--- a/app/containers/BudgetItem/style.scss
+++ b/app/containers/BudgetItem/style.scss
@@ -1,0 +1,16 @@
+@import 'theme/variables';
+
+.budgetItemPos::before {
+  color: $green;
+  content: "+";
+}
+
+.budgetItemNeg::before {
+  color: $red;
+  content: "-";
+}
+
+:export {
+  pos: $green;
+  neg: $red;
+}

--- a/app/routes/Budget/index.js
+++ b/app/routes/Budget/index.js
@@ -1,12 +1,13 @@
 // @flow
 import React, { Component } from 'react';
 import Chunk from 'components/Chunk';
+import { type RouterHistory } from 'react-router';
 
 const loadBudgetContainer = () => import('containers/Budget' /* webpackChunkName: "budget" */);
 
-class Budget extends Component<{}> {
+class Budget extends Component<{ history: RouterHistory }> {
   render() {
-    return <Chunk load={loadBudgetContainer} />;
+    return <Chunk load={loadBudgetContainer} history={this.props.history} />;
   }
 }
 

--- a/app/routes/BudgetItem/index.js
+++ b/app/routes/BudgetItem/index.js
@@ -1,0 +1,14 @@
+// @flow
+import React, { Component } from 'react';
+import Chunk from 'components/Chunk';
+import { type Match } from 'react-router';
+
+const loadBudgetItemContainer = () => import('containers/BudgetItem' /* webpackChunkName: "budgetItem" */);
+
+class BudgetItem extends Component<{ match: Match }> {
+  render() {
+    return <Chunk load={loadBudgetItemContainer} id={this.props.match.params.id} />;
+  }
+}
+
+export default BudgetItem;


### PR DESCRIPTION
## Feature
As a user, I want to see percentage of total budget an item is
contributing with, so I can better understand statistics of my inflow or
outflow items

## Acceptance Criteria
- Given that I have added at least one item to the budgeting grid
- When I click on that item
- Then I want to see a new page with a title corresponding to the item details
- And route should be dynamic with item ID in it
- And a subtitle under title should show percentage with red minus sign showing outflow, green plus sign for inflow
- And a pie chart showing how much of the entire budget this item is contributing with should be on that page
- And no other items from the budget should be on that pie chart
- And there should be a back button to return back to the previous route
- And the view should be mobile and desktop compatible
- No special styling is necessary.

## Proposed Changes

* Added the `/budget/:id` route
* Handled the situation when `id` is not found in the transaction list
* Updated unit tests & Flow type declarations as needed
* Re-used the existing DonutChart (had to modify it slightly, all tests pass and reporting works as expected)
* Styles are a little ugly, although didn't change them purposely following the "no special styling is necessary" requirement
* Added "cursor: pointer" style to the BudgetGridRow in order to give the user a clue that it is clickable (the only case when the rule above was broken)
* Fixed the small issue in DonutChart when passing the domain values for the ordinal color scale
* Fixed the small issue on the `/budget` page when the negative working balance displayed in green

## Screenshot

![modus](https://user-images.githubusercontent.com/527503/34097242-b43b7a04-e3d8-11e7-9aa8-8e22f3d20de6.gif)

## Checklist

* [x] Feature developed
* [x] Created/updated unit tests
* [x] Comments in code (only few of them, when necessary)
* [x] Documentation written (the PR description)
