### PR TITLE
Budget item page

### DIFF
--- a/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
@@ -1,7 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<tr>
+<tr
+  className="budgetGridRow"
+  onClick={[Function]}
+>
   <td>
     <div
       className="cellLabel"

--- a/app/components/BudgetGridRow/__tests__/index-test.js
+++ b/app/components/BudgetGridRow/__tests__/index-test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { StaticRouter } from 'react-router-dom';
 import BudgetGridRow from 'components/BudgetGridRow';
 
 it('renders correctly', () => {
@@ -15,6 +16,15 @@ it('renders correctly', () => {
     2: 'School',
   };
 
-  const tree = renderer.create(<BudgetGridRow transaction={mockTransaction} categories={mockCategories} />).toJSON();
+  const mockRouterContext = {};
+
+  const tree = renderer
+    .create(
+      <StaticRouter context={mockRouterContext}>
+        <BudgetGridRow transaction={mockTransaction} categories={mockCategories} />
+      </StaticRouter>
+    )
+    .toJSON();
+
   expect(tree).toMatchSnapshot();
 });

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -19,6 +19,7 @@ const BudgetGridRow = ({ transaction, categories, history }: BudgetGridRowProps)
   const { id, categoryId, description } = transaction;
   const category = categories[categoryId];
 
+  // change url to item detail page (using react-router history object)
   const onOpenItemDetail = () => {
     history.push(`/item/${id}`);
   };

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -1,23 +1,30 @@
 // @flow
 import * as React from 'react';
+import { withRouter } from 'react-router-dom';
 import formatAmount from 'utils/formatAmount';
 import type { Transaction } from 'modules/transactions';
 import type { Categories } from 'modules/categories';
+import type { RouterHistory } from 'react-router-dom';
 import styles from './style.scss';
 
 type BudgetGridRowProps = {
   transaction: Transaction,
   categories: Categories,
+  history: RouterHistory,
 };
 
-const BudgetGridRow = ({ transaction, categories }: BudgetGridRowProps) => {
+const BudgetGridRow = ({ transaction, categories, history }: BudgetGridRowProps) => {
   const amount = formatAmount(transaction.value);
   const amountCls = amount.isNegative ? styles.neg : styles.pos;
   const { id, categoryId, description } = transaction;
   const category = categories[categoryId];
 
+  const onOpenItemDetail = () => {
+    history.push(`/item/${id}`);
+  };
+
   return (
-    <tr key={id}>
+    <tr className={styles.budgetGridRow} onClick={onOpenItemDetail} key={id}>
       <td>
         <div className={styles.cellLabel}>Category</div>
         <div className={styles.cellContent}>{category}</div>
@@ -34,4 +41,4 @@ const BudgetGridRow = ({ transaction, categories }: BudgetGridRowProps) => {
   );
 };
 
-export default BudgetGridRow;
+export default withRouter(BudgetGridRow);

--- a/app/components/BudgetGridRow/style.scss
+++ b/app/components/BudgetGridRow/style.scss
@@ -1,5 +1,13 @@
 @import 'theme/variables';
 
+.budgetGridRow {
+  cursor: pointer;
+
+  &:hover {
+    background: $verylightgray;
+  }
+}
+
 .cellLabel {
   display: none;
 

--- a/app/components/Legend/index.js
+++ b/app/components/Legend/index.js
@@ -1,12 +1,11 @@
 // @flow
 import * as React from 'react';
 import cx from 'classnames';
-import type { TransactionSummary } from 'selectors/transactions';
 import LegendItem from './LegendItem';
 import styles from './styles.scss';
 
 type LegendType = {
-  data: TransactionSummary[],
+  data: any,
   dataValue: string,
   dataLabel: string,
   dataKey: string,

--- a/app/components/PieChart/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/PieChart/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<div
+  className="pieChart"
+>
+  <div
+    height={316}
+    padding={8}
+    transform="translate(150,150)"
+    width={316}
+  />
+  <div
+    color={[Function]}
+    data={Array []}
+    dataKey="test"
+    dataLabel="test"
+    dataValue="value"
+  />
+</div>
+`;

--- a/app/components/PieChart/__tests__/index-test.js
+++ b/app/components/PieChart/__tests__/index-test.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import DonutChart from '../';
+
+// mock nested components
+jest.mock('components/DonutChart/Path');
+jest.mock('components/Chart', () => 'div');
+jest.mock('components/Legend', () => 'div');
+
+it('renders correctly', () => {
+  const tree = renderer.create(<DonutChart dataLabel="test" dataKey="test" data={[]} />).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/components/PieChart/index.js
+++ b/app/components/PieChart/index.js
@@ -1,0 +1,107 @@
+// @flow
+
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import Legend from 'components/Legend';
+import Chart from 'components/Chart';
+import { arc, pie, scaleOrdinal, schemeCategory20 } from 'd3';
+import { shuffle } from 'utils/array';
+import Path from 'components/DonutChart/Path';
+import styles from './styles.scss';
+
+const randomScheme = shuffle(schemeCategory20);
+
+export type PieChartData = {
+  value: number,
+  label: string,
+};
+
+type PieChartProps = {
+  data: PieChartData[],
+  dataLabel: string,
+  dataKey: string,
+  dataValue: string,
+  color: Function,
+  height: number,
+};
+
+class PieChart extends React.Component<PieChartProps> {
+  static defaultProps = {
+    color: scaleOrdinal(randomScheme),
+    height: 300,
+    dataValue: 'value',
+  };
+
+  static propTypes = {
+    data: PropTypes.arrayOf(PropTypes.object).isRequired,
+    dataLabel: PropTypes.string.isRequired,
+    dataKey: PropTypes.string.isRequired,
+    dataValue: PropTypes.string,
+    color: PropTypes.func,
+    height: PropTypes.number,
+  };
+
+  componentWillMount() {
+    this.updateChartVariables();
+  }
+
+  componentWillReceiveProps(nextProps: PieChartProps) {
+    const { data, color, height } = nextProps;
+
+    const old = this.props;
+
+    if (old.data !== data || old.color !== color || old.height !== height) {
+      this.updateChartVariables();
+    }
+  }
+
+  getPathArc = () => {
+    const { height } = this.props;
+    return arc()
+      .innerRadius(0)
+      .outerRadius(height / 2);
+  };
+
+  chart: any;
+  pathArc: any;
+  colorFn: any;
+  outerRadius: number;
+  boxLength: number;
+  chartPadding = 8;
+
+  updateChartVariables = () => {
+    const { data, dataValue, color, height } = this.props;
+
+    this.chart = pie()
+      .value(d => d[dataValue])
+      .sort(null);
+    this.outerRadius = height / 2;
+    this.pathArc = this.getPathArc();
+    this.colorFn = color.domain && color.domain([0, data.length]);
+    this.boxLength = height + this.chartPadding * 2;
+  };
+
+  render() {
+    const { data, dataLabel, dataValue, dataKey } = this.props;
+    const { outerRadius, pathArc, colorFn, boxLength, chartPadding } = this;
+
+    return (
+      <div className={styles.pieChart}>
+        <Chart
+          width={boxLength}
+          height={boxLength}
+          padding={chartPadding}
+          transform={`translate(${outerRadius},${outerRadius})`}
+        >
+          {this.chart(data).map((datum, index) => (
+            <Path data={datum} index={index} fill={colorFn(index)} arcFn={pathArc} key={datum.data[dataKey]} />
+          ))}
+        </Chart>
+
+        <Legend color={colorFn} {...{ data, dataValue, dataLabel, dataKey }} />
+      </div>
+    );
+  }
+}
+
+export default PieChart;

--- a/app/components/PieChart/styles.scss
+++ b/app/components/PieChart/styles.scss
@@ -1,0 +1,7 @@
+.pieChart {
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  align-content: flex-start;
+  flex-flow: wrap;
+}

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -6,6 +6,7 @@ import ErrorBoundary from 'components/ErrorBoundary';
 import AppError from 'components/AppError';
 import Header from 'components/Header';
 import Budget from 'routes/Budget';
+import BudgetItemDetails from 'routes/BudgetItemDetails';
 import Reports from 'routes/Reports';
 import './style.scss';
 
@@ -17,6 +18,7 @@ const App = () => (
       <Switch>
         <Route path="/budget" component={Budget} />
         <Route path="/reports" component={Reports} />
+        <Route path="/item/:itemId" component={BudgetItemDetails} />
         <Redirect to="/budget" />
       </Switch>
     </main>

--- a/app/containers/BudgetItemDetails/__tests__/__snapshots__/index-test.js.snap
+++ b/app/containers/BudgetItemDetails/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<div
+  className="budgetItemDetails"
+>
+  <div
+    className="goBackButton goBackButton"
+    onClick={[Function]}
+    role="button"
+    tabIndex="0"
+  >
+    Back
+  </div>
+  <div>
+    <h1>
+      Trader Joe's food
+    </h1>
+    <h2>
+      Amount 
+      spent
+      : 
+       
+      <span
+        className="textRed"
+      >
+        -$423.34
+      </span>
+    </h2>
+    <h3>
+      which is 
+      18.0%
+       of total 
+      outflow
+       
+       
+      <span
+        className="textRed"
+      >
+        -$2,346.00
+      </span>
+    </h3>
+  </div>
+</div>
+`;

--- a/app/containers/BudgetItemDetails/__tests__/__snapshots__/index-test.js.snap
+++ b/app/containers/BudgetItemDetails/__tests__/__snapshots__/index-test.js.snap
@@ -12,14 +12,16 @@ exports[`renders correctly 1`] = `
   >
     Back
   </div>
-  <div>
+  <div
+    className="mainText"
+  >
     <h1>
       Trader Joe's food
     </h1>
     <h2>
       Amount 
       spent
-      : 
+      :
        
       <span
         className="textRed"
@@ -33,13 +35,46 @@ exports[`renders correctly 1`] = `
        of total 
       outflow
        
-       
       <span
         className="textRed"
       >
         -$2,346.00
       </span>
     </h3>
+  </div>
+  <div
+    className="pieChart"
+  >
+    <svg
+      className="mainSvg"
+      height={316}
+      viewBox="-8 -8 316 316"
+      width={316}
+    >
+      <g
+        transform="translate(150,150)"
+      />
+    </svg>
+    <div
+      color={[Function]}
+      data={
+        Array [
+          Object {
+            "key": "value",
+            "label": "Trader Joe's food",
+            "value": 423.34,
+          },
+          Object {
+            "key": "remaining",
+            "label": "Rest of outflows",
+            "value": 1922.66,
+          },
+        ]
+      }
+      dataKey="key"
+      dataLabel="label"
+      dataValue="value"
+    />
   </div>
 </div>
 `;

--- a/app/containers/BudgetItemDetails/__tests__/index-test.js
+++ b/app/containers/BudgetItemDetails/__tests__/index-test.js
@@ -3,6 +3,9 @@ import { shallow } from 'enzyme';
 import renderer from 'react-test-renderer';
 import { BudgetItemDetails } from 'containers/BudgetItemDetails';
 
+jest.mock('components/DonutChart/Path');
+jest.mock('components/Legend', () => 'div');
+
 it('renders correctly', () => {
   const mockTransactions = [
     {
@@ -10,6 +13,12 @@ it('renders correctly', () => {
       description: "Trader Joe's food",
       value: -423.34,
       categoryId: 1,
+    },
+    {
+      id: 2,
+      description: 'More books :) And some long text to see if elipsis works',
+      value: -623.34,
+      categoryId: 2,
     },
   ];
 

--- a/app/containers/BudgetItemDetails/__tests__/index-test.js
+++ b/app/containers/BudgetItemDetails/__tests__/index-test.js
@@ -1,0 +1,96 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import renderer from 'react-test-renderer';
+import { BudgetItemDetails } from 'containers/BudgetItemDetails';
+
+it('renders correctly', () => {
+  const mockTransactions = [
+    {
+      id: 1,
+      description: "Trader Joe's food",
+      value: -423.34,
+      categoryId: 1,
+    },
+  ];
+
+  const mockCategories = {
+    1: 'Groceries',
+    2: 'School',
+  };
+
+  const mockRouterMatch = {
+    path: '/item/:itemId',
+    url: '/item/1',
+    isExact: true,
+    params: { itemId: '1' },
+  };
+
+  const mockRouterHistory = {
+    goBack: jest.fn(),
+  };
+
+  const mockInflowBalance = 3456;
+  const mockOutflowBalance = -2346;
+
+  const tree = renderer
+    .create(
+      <BudgetItemDetails
+        match={mockRouterMatch}
+        history={mockRouterHistory}
+        inflowBalance={mockInflowBalance}
+        outflowBalance={mockOutflowBalance}
+        transactions={mockTransactions}
+        categories={mockCategories}
+      />
+    )
+    .toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
+it('correctly calls goBack on Back button click', () => {
+  const mockTransactions = [
+    {
+      id: 1,
+      description: "Trader Joe's food",
+      value: -423.34,
+      categoryId: 1,
+    },
+  ];
+
+  const mockCategories = {
+    1: 'Groceries',
+    2: 'School',
+  };
+
+  const mockRouterMatch = {
+    path: '/item/:itemId',
+    url: '/item/1',
+    isExact: true,
+    params: { itemId: '1' },
+  };
+
+  const mockGoBack = jest.fn();
+
+  const mockRouterHistory = {
+    goBack: mockGoBack,
+  };
+
+  const mockInflowBalance = 3456;
+  const mockOutflowBalance = -2346;
+
+  const wrapper = shallow(
+    <BudgetItemDetails
+      match={mockRouterMatch}
+      history={mockRouterHistory}
+      inflowBalance={mockInflowBalance}
+      outflowBalance={mockOutflowBalance}
+      transactions={mockTransactions}
+      categories={mockCategories}
+    />
+  );
+
+  wrapper.find('.goBackButton').simulate('click');
+
+  expect(mockGoBack).toHaveBeenCalled();
+});

--- a/app/containers/BudgetItemDetails/index.js
+++ b/app/containers/BudgetItemDetails/index.js
@@ -49,7 +49,7 @@ export const BudgetItemDetails = ({
       <div>
         <h1>{item.description}</h1>
         <h2>
-          Amount {isInflow ? 'in' : 'spent'}: {' '}
+          Amount {isInflow ? 'in' : 'spent'}:{' '}
           {isInflow ? (
             <span className={styles.textGreen}>{formatAmount(item.value).text}</span>
           ) : (
@@ -57,7 +57,7 @@ export const BudgetItemDetails = ({
           )}
         </h2>
         <h3>
-          which is {percentageOfTotal} of total {isInflow ? 'inflow' : 'outflow'} {' '}
+          which is {percentageOfTotal} of total {isInflow ? 'inflow' : 'outflow'}{' '}
           {isInflow ? (
             <span className={styles.textGreen}>{formatAmount(inflowBalance).text}</span>
           ) : (

--- a/app/containers/BudgetItemDetails/index.js
+++ b/app/containers/BudgetItemDetails/index.js
@@ -1,0 +1,99 @@
+// @flow
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { injectAsyncReducers } from 'store';
+import { withRouter } from 'react-router-dom';
+import type { Match, RouterHistory } from 'react-router-dom';
+import { getTransactions, getInflowBalance, getOutflowBalance } from '../../selectors/transactions';
+import transactionReducer from '../../modules/transactions';
+import type { Transaction } from '../../modules/transactions';
+import formatPercentage from '../../utils/formatPercentage';
+import formatAmount from '../../utils/formatAmount';
+import styles from './style.scss';
+
+// inject reducers that might not have been originally there
+injectAsyncReducers({
+  transactions: transactionReducer,
+});
+
+type BudgetItemDetailsProps = {
+  match: Match,
+  transactions: Transaction[],
+  history: RouterHistory,
+  inflowBalance: number,
+  outflowBalance: number,
+};
+
+export const BudgetItemDetails = ({
+  match,
+  transactions,
+  history,
+  inflowBalance,
+  outflowBalance,
+}: BudgetItemDetailsProps) => {
+  const getItem = itemIdToGet => ({ id }) => id === Number(itemIdToGet);
+  const { itemId } = match.params;
+  const item = transactions.filter(getItem(itemId))[0];
+
+  const isInflow = item.value > 0;
+  const percentageOfTotal = formatPercentage(item.value / (isInflow ? inflowBalance : outflowBalance) * 100, {
+    decimals: 1,
+  });
+
+  return (
+    <div className={styles.budgetItemDetails}>
+      <div className={`goBackButton ${styles.goBackButton}`} onClick={history.goBack} role="button" tabIndex="0">
+        Back
+      </div>
+      <div>
+        <h1>{item.description}</h1>
+        <h2>
+          Amount {isInflow ? 'in' : 'spent'}: {' '}
+          {isInflow ? (
+            <span className={styles.textGreen}>{formatAmount(item.value).text}</span>
+          ) : (
+            <span className={styles.textRed}>{formatAmount(item.value).text}</span>
+          )}
+        </h2>
+        <h3>
+          which is {percentageOfTotal} of total {isInflow ? 'inflow' : 'outflow'} {' '}
+          {isInflow ? (
+            <span className={styles.textGreen}>{formatAmount(inflowBalance).text}</span>
+          ) : (
+            <span className={styles.textRed}>{formatAmount(outflowBalance).text}</span>
+          )}
+        </h3>
+      </div>
+    </div>
+  );
+};
+
+BudgetItemDetails.propTypes = {
+  inflowBalance: PropTypes.number.isRequired,
+  outflowBalance: PropTypes.number.isRequired,
+  history: PropTypes.shape({
+    goBack: PropTypes.func.isRequired,
+  }).isRequired,
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      itemId: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
+  transactions: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      description: PropTypes.string.isRequired,
+      value: PropTypes.number.isRequired,
+    })
+  ).isRequired,
+};
+
+const mapStateToProps = state => ({
+  transactions: getTransactions(state),
+  inflowBalance: getInflowBalance(state),
+  outflowBalance: getOutflowBalance(state),
+});
+const mapDispatchToProps = () => ({});
+
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(BudgetItemDetails));

--- a/app/containers/BudgetItemDetails/index.js
+++ b/app/containers/BudgetItemDetails/index.js
@@ -8,6 +8,7 @@ import type { Match, RouterHistory } from 'react-router-dom';
 import { getTransactions, getInflowBalance, getOutflowBalance } from '../../selectors/transactions';
 import transactionReducer from '../../modules/transactions';
 import type { Transaction } from '../../modules/transactions';
+import PieChart from '../../components/PieChart';
 import formatPercentage from '../../utils/formatPercentage';
 import formatAmount from '../../utils/formatAmount';
 import styles from './style.scss';
@@ -41,12 +42,18 @@ export const BudgetItemDetails = ({
     decimals: 1,
   });
 
+  const MAX_DESC_LENGTH = 25;
+  const shortenedDescriptionForChart =
+    item.description.length > MAX_DESC_LENGTH + 3
+      ? `${item.description.substr(0, MAX_DESC_LENGTH)}...`
+      : item.description;
+
   return (
     <div className={styles.budgetItemDetails}>
       <div className={`goBackButton ${styles.goBackButton}`} onClick={history.goBack} role="button" tabIndex="0">
         Back
       </div>
-      <div>
+      <div className={styles.mainText}>
         <h1>{item.description}</h1>
         <h2>
           Amount {isInflow ? 'in' : 'spent'}:{' '}
@@ -65,6 +72,22 @@ export const BudgetItemDetails = ({
           )}
         </h3>
       </div>
+      <PieChart
+        data={[
+          {
+            key: 'value',
+            value: Math.abs(item.value),
+            label: shortenedDescriptionForChart,
+          },
+          {
+            key: 'remaining',
+            value: Math.abs(isInflow ? inflowBalance : outflowBalance) - Math.abs(item.value),
+            label: `Rest of ${isInflow ? ' inflows' : 'outflows'}`,
+          },
+        ]}
+        dataLabel="label"
+        dataKey="key"
+      />
     </div>
   );
 };

--- a/app/containers/BudgetItemDetails/index.js
+++ b/app/containers/BudgetItemDetails/index.js
@@ -33,21 +33,29 @@ export const BudgetItemDetails = ({
   inflowBalance,
   outflowBalance,
 }: BudgetItemDetailsProps) => {
-  const getItem = itemIdToGet => ({ id }) => id === Number(itemIdToGet);
+  // retrieve item ID from props.match (router url match object)
   const { itemId } = match.params;
+
+  // retrieve inflow/outflow item from state
+  const getItem = itemIdToGet => ({ id }) => id === Number(itemIdToGet);
   const item = transactions.filter(getItem(itemId))[0];
 
+  // determine if item is inflow or outflow
   const isInflow = item.value > 0;
+
+  // calculate what percentage the value is of the total inflow/outflow
   const percentageOfTotal = formatPercentage(item.value / (isInflow ? inflowBalance : outflowBalance) * 100, {
     decimals: 1,
   });
 
+  // shorten description (with ellipsis) for chart legend
   const MAX_DESC_LENGTH = 25;
   const shortenedDescriptionForChart =
     item.description.length > MAX_DESC_LENGTH + 3
       ? `${item.description.substr(0, MAX_DESC_LENGTH)}...`
       : item.description;
 
+  // return render
   return (
     <div className={styles.budgetItemDetails}>
       <div className={`goBackButton ${styles.goBackButton}`} onClick={history.goBack} role="button" tabIndex="0">
@@ -80,6 +88,9 @@ export const BudgetItemDetails = ({
             label: shortenedDescriptionForChart,
           },
           {
+            // show remaining amount in chart, to illustrate how large the spending is of the total inflow/outflow
+            // e.g. 100 spent on item, and 1000 is total outflow: so, draw a pie chart
+            //      with 100 slice -> (item value) AND 900 slice -> (total 1000 minus 100)
             key: 'remaining',
             value: Math.abs(isInflow ? inflowBalance : outflowBalance) - Math.abs(item.value),
             label: `Rest of ${isInflow ? ' inflows' : 'outflows'}`,

--- a/app/containers/BudgetItemDetails/style.scss
+++ b/app/containers/BudgetItemDetails/style.scss
@@ -20,6 +20,21 @@
       box-shadow: 1px 1px 10px rgba(0, 0, 0, 0.2);
       opacity: 1;
     }
+
+    @media screen and (max-height: 50em) {
+      margin-top:3rem;
+    }
+  }
+
+  .mainText {
+    max-width: 500px;
+    width:calc(100% - 2rem);
+    margin: {
+      top:0;
+      left: auto;
+      right: auto;
+      bottom: 3rem;
+    }
   }
 
   .textGreen {

--- a/app/containers/BudgetItemDetails/style.scss
+++ b/app/containers/BudgetItemDetails/style.scss
@@ -1,0 +1,33 @@
+@import 'theme/variables';
+
+.budgetItemDetails {
+
+  .goBackButton {
+    display: inline-block;
+    border: solid 1px $green;
+    border-radius: 3px;
+    padding: 0.5rem 1.5rem;
+    font-size: 16px;
+    cursor: pointer;
+    box-shadow: 1px 1px 10px rgba(0, 0, 0, 0.1);
+
+    &:hover {
+      box-shadow: 1px 1px 10px rgba(0, 0, 0, 0.15);
+      opacity: 0.6;
+    }
+
+    &:active {
+      box-shadow: 1px 1px 10px rgba(0, 0, 0, 0.2);
+      opacity: 1;
+    }
+  }
+
+  .textGreen {
+    color: $green;
+  }
+
+  .textRed {
+    color: $red;
+  }
+
+}

--- a/app/routes/BudgetItemDetails/index.js
+++ b/app/routes/BudgetItemDetails/index.js
@@ -1,0 +1,21 @@
+// @flow
+import React, { Component } from 'react';
+import Chunk from 'components/Chunk';
+import type { Match } from 'react-router-dom';
+
+const loadBudgetItemDetailsContainer = () =>
+  import('containers/BudgetItemDetails' /* webpackChunkName: "budget-item-details" */);
+
+type BudgetItemDetailsProps = {
+  match: Match,
+};
+
+class BudgetItemDetails extends Component<BudgetItemDetailsProps> {
+  render() {
+    const { match } = this.props;
+
+    return <Chunk load={loadBudgetItemDetailsContainer} match={match} />;
+  }
+}
+
+export default BudgetItemDetails;

--- a/app/utils/__tests__/formatPercentage-test.js
+++ b/app/utils/__tests__/formatPercentage-test.js
@@ -1,0 +1,41 @@
+import formatPercentage from '../formatPercentage';
+
+describe('formatPercentage utility function', () => {
+  it('correctly handles a basic format', () => {
+    const valueToFormat = 345.34564;
+
+    const result = formatPercentage(valueToFormat);
+
+    expect(result).toBe('345.35%');
+  });
+
+  it('correctly handles a format with custom decimal places', () => {
+    const valueToFormat = 12356.345789;
+
+    const result = formatPercentage(valueToFormat, {
+      decimals: 4,
+    });
+
+    expect(result).toBe('12356.3458%');
+  });
+
+  it('correctly handles negative values', () => {
+    const valueToFormat = -1234.823;
+
+    const result = formatPercentage(valueToFormat, {
+      decimals: 1,
+    });
+
+    expect(result).toBe('-1234.8%');
+  });
+
+  it('correctly adds decimals even if not necessary', () => {
+    const valueToFormat = 555;
+
+    const result = formatPercentage(valueToFormat, {
+      decimals: 3,
+    });
+
+    expect(result).toBe('555.000%');
+  });
+});

--- a/app/utils/formatPercentage.js
+++ b/app/utils/formatPercentage.js
@@ -3,6 +3,7 @@ type OptionsTypes = {
   decimals: number,
 };
 
+// converts a number value such as (3145.2356345) to a percentage string with fixed decimals (e.g. 3145.24%)
 const formatPercentage = (value: number, { decimals = 2 }: OptionsTypes = {}): string =>
   `${String(value.toFixed(decimals))}%`;
 

--- a/app/utils/formatPercentage.js
+++ b/app/utils/formatPercentage.js
@@ -1,0 +1,9 @@
+// @flow
+type OptionsTypes = {
+  decimals: number,
+};
+
+const formatPercentage = (value: number, { decimals = 2 }: OptionsTypes = {}): string =>
+  `${String(value.toFixed(decimals))}%`;
+
+export default formatPercentage;


### PR DESCRIPTION
## Proposed Changes
Created a page to display budget item details, including a pie-chart to illustrate how much that items makes up of the total inflow/outflow. The page can be opened by clicking on an item in the budget items list.

* Item on budget page can be clicked
* Route changes open item page open
* Added a pie-chart to illustrate
* Added a Back button to return to previous page
* Mobile responsive
* Added/updated unit tests
* Flow type checked
* Added propTypes for runtime props checking

## Screenshot

1. Made item row clickable:
![made-item-row-clickable](https://user-images.githubusercontent.com/2068404/36306769-8fcad33e-1319-11e8-8173-a6fdeff9513a.jpg)

2. Added an item details page:
![item-details-page](https://user-images.githubusercontent.com/2068404/36306775-997f607a-1319-11e8-8db5-e7516f62efa8.jpg)

3. Implemented mobile-responsiveness
![mobile-responsive](https://user-images.githubusercontent.com/2068404/36306793-a9ee8ff8-1319-11e8-9e5f-e8a66ea67a1c.jpg)

## Checklist

* [x] Feature developed
* [x] Created/updated unit tests
* [x] Comments in code
* [ ] Documentation written
