### PR TITLE
[Feature][As a user, I want to see percentage of total budget an item…

### DIFF
--- a/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<tr>
+<tr
+  onClick={[Function]}
+>
   <td>
     <div
       className="cellLabel"

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -7,31 +7,48 @@ import styles from './style.scss';
 
 type BudgetGridRowProps = {
   transaction: Transaction,
-  categories: Categories,
+  categories: Categories[],
+  history: object,
 };
 
-const BudgetGridRow = ({ transaction, categories }: BudgetGridRowProps) => {
-  const amount = formatAmount(transaction.value);
-  const amountCls = amount.isNegative ? styles.neg : styles.pos;
-  const { id, categoryId, description } = transaction;
-  const category = categories[categoryId];
+class BudgetGridRow extends React.Component<BudgetGridRowProps>{
 
-  return (
-    <tr key={id}>
-      <td>
-        <div className={styles.cellLabel}>Category</div>
-        <div className={styles.cellContent}>{category}</div>
-      </td>
-      <td>
-        <div className={styles.cellLabel}>Description</div>
-        <div className={styles.cellContent}>{description}</div>
-      </td>
-      <td className={amountCls}>
-        <div className={styles.cellLabel}>Amount</div>
-        <div className={styles.cellContent}>{amount.text}</div>
-      </td>
-    </tr>
-  );
-};
+  static defaultProps = {
+    transaction: {},
+    categories: [],
+    history: {},
+  };
+
+  //Redirect the page to item/:itemId page
+  goToBudgetItem = id => {
+    const { history } = this.props;
+    history.push(`/item/${id}`);
+  };
+
+  render(){
+    const { transaction, categories } = this.props;
+    const amount = formatAmount(transaction.value);
+    const amountCls = amount.isNegative ? styles.neg : styles.pos;
+    const { id, categoryId, description } = transaction;
+    const category = categories[categoryId];
+
+    return (
+      <tr key={id} onClick={() => this.goToBudgetItem(id)}>
+        <td>
+          <div className={styles.cellLabel}>Category</div>
+          <div className={styles.cellContent}>{category}</div>
+        </td>
+        <td>
+          <div className={styles.cellLabel}>Description</div>
+          <div className={styles.cellContent}>{description}</div>
+        </td>
+        <td className={amountCls}>
+          <div className={styles.cellLabel}>Amount</div>
+          <div className={styles.cellContent}>{amount.text}</div>
+        </td>
+      </tr>
+    );
+  }
+}
 
 export default BudgetGridRow;

--- a/app/components/ClickableRow/index.js
+++ b/app/components/ClickableRow/index.js
@@ -1,0 +1,20 @@
+// @flow
+import * as React from 'react';
+import { Route } from 'react-router-dom';
+import type { Transaction } from 'modules/transactions';
+import type { Categories } from 'modules/categories';
+import BudgetGridRow from 'components/BudgetGridRow';
+
+type ClickableRowProps = {
+  transaction: Transaction,
+  categories: Categories,
+};
+
+//To make the BudgetGridRow a clickable row
+const ClickableRow = ({ transaction, categories }: ClickableRowProps) => (
+  <Route
+    render={({ history }) => <BudgetGridRow history={history} transaction={transaction} categories={categories} />}
+  />
+);
+
+export default ClickableRow;

--- a/app/components/DonutChart/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/DonutChart/__tests__/__snapshots__/index-test.js.snap
@@ -16,6 +16,7 @@ exports[`renders correctly 1`] = `
     dataKey="test"
     dataLabel="test"
     dataValue="value"
+    valueFormat={undefined}
   />
 </div>
 `;

--- a/app/components/DonutChart/index.js
+++ b/app/components/DonutChart/index.js
@@ -19,6 +19,7 @@ type DonutChartProps = {
   color: Function,
   height: number,
   innerRatio: number,
+  valueFormat: Function, //New function is added to display customized formats
 };
 
 class DonutChart extends React.Component<DonutChartProps> {
@@ -70,9 +71,8 @@ class DonutChart extends React.Component<DonutChartProps> {
   };
 
   render() {
-    const { data, dataLabel, dataValue, dataKey } = this.props;
+    const { data, dataLabel, dataValue, dataKey, valueFormat } = this.props;
     const { outerRadius, pathArc, colorFn, boxLength, chartPadding } = this;
-
     return (
       <div className={styles.donutChart}>
         <Chart
@@ -86,7 +86,7 @@ class DonutChart extends React.Component<DonutChartProps> {
           ))}
         </Chart>
 
-        <Legend color={colorFn} {...{ data, dataValue, dataLabel, dataKey }} />
+        <Legend color={colorFn} {...{ data, dataValue, dataLabel, dataKey, valueFormat }} />
       </div>
     );
   }

--- a/app/components/Legend/LegendItem.js
+++ b/app/components/Legend/LegendItem.js
@@ -7,13 +7,20 @@ type LegendItemProps = {
   color: string,
   value: number,
   label: string,
+  valueFormat: Function,
 };
 
-const LegendItem = ({ color, label, value }: LegendItemProps) => (
-  <li style={{ color }}>
-    <span>{label}</span>
-    <span className={styles.value}> {formatAmount(value).text} </span>
-  </li>
-);
+const LegendItem = ({ color, label, value, valueFormat }: LegendItemProps) => {
+  let formattedValue = formatAmount(value).text;
+  if (valueFormat) { //If a customized format is defined it will be executed
+    formattedValue = valueFormat(value);
+  }
+  return (
+    <li style={{ color }}>
+      <span>{label}</span>
+      <span className={styles.value}> {formattedValue} </span>
+    </li>
+  );
+};
 
 export default LegendItem;

--- a/app/components/Legend/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/Legend/__tests__/__snapshots__/index-test.js.snap
@@ -8,11 +8,13 @@ exports[`renders correctly 1`] = `
     color={undefined}
     label={undefined}
     value={undefined}
+    valueFormat={undefined}
   />
   <div
     color={undefined}
     label={undefined}
     value={undefined}
+    valueFormat={undefined}
   />
 </ul>
 `;

--- a/app/components/Legend/index.js
+++ b/app/components/Legend/index.js
@@ -12,12 +12,19 @@ type LegendType = {
   dataKey: string,
   color: Function,
   reverse: boolean,
+  valueFormat: Function,
 };
 
-const Legend = ({ data, color, dataValue, dataLabel, dataKey, reverse }: LegendType) => (
+const Legend = ({ data, color, dataValue, dataLabel, dataKey, reverse , valueFormat}: LegendType) => (
   <ul className={cx(styles.legend, { [styles.reverse]: reverse })}>
     {data.map((item, idx) => (
-      <LegendItem color={color(idx)} key={item[dataKey]} label={item[dataLabel]} value={item[dataValue]} />
+      <LegendItem
+        color={color(idx)}
+        key={item[dataKey]}
+        label={item[dataLabel]}
+        value={item[dataValue]}
+        valueFormat={valueFormat}
+      />
     ))}
   </ul>
 );

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -7,6 +7,7 @@ import AppError from 'components/AppError';
 import Header from 'components/Header';
 import Budget from 'routes/Budget';
 import Reports from 'routes/Reports';
+import BudgetItem from 'routes/BudgetItem';
 import './style.scss';
 
 const App = () => (
@@ -17,6 +18,7 @@ const App = () => (
       <Switch>
         <Route path="/budget" component={Budget} />
         <Route path="/reports" component={Reports} />
+        <Route path="/item/:itemId" render={props => <BudgetItem {...props} />} />
         <Redirect to="/budget" />
       </Switch>
     </main>

--- a/app/containers/BudgetGrid/index.js
+++ b/app/containers/BudgetGrid/index.js
@@ -5,7 +5,7 @@ import { getTransactions } from 'selectors/transactions';
 import { getCategories } from 'selectors/categories';
 import EntryFormRow from 'containers/EntryFormRow';
 import type { Transaction } from 'modules/transactions';
-import BudgetGridRow from 'components/BudgetGridRow';
+import ClickableRow from 'components/ClickableRow';
 import styles from './style.scss';
 
 type BudgetGridProps = {
@@ -33,7 +33,7 @@ export class BudgetGrid extends React.Component<BudgetGridProps> {
         </thead>
         <tbody>
           {transactions.map((transaction: Transaction): React.Element<any> => (
-            <BudgetGridRow key={transaction.id} transaction={transaction} categories={categories} />
+            <ClickableRow key={transaction.id} transaction={transaction} categories={categories} />
           ))}
         </tbody>
         <tfoot>

--- a/app/containers/BudgetItem/index.js
+++ b/app/containers/BudgetItem/index.js
@@ -1,0 +1,69 @@
+// @flow
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { injectAsyncReducers } from 'store';
+import transactionReducer from 'modules/transactions';
+import type { Transaction } from 'modules/transactions';
+import { getTransactions, getTransaction } from 'selectors/transactions';
+import DonutChart from 'components/DonutChart';
+import styles from './style.scss';
+import formatAmount from 'utils/formatAmount';
+import formatToPercentage from 'utils/formatToPercentage';
+import { getWorkingBalance } from '../../selectors/transactions';
+import NavLink from 'components/NavLink';
+
+injectAsyncReducers({
+  transactions: transactionReducer,
+});
+
+type BudgetItemProps = {
+  transaction: Transaction,
+  workingBalance: Number,
+};
+
+class BudgetItem extends React.Component<BudgetItemProps> {
+  static defaultProps = {
+    transaction: {},
+    workingBalance: 0,
+  };
+
+  goBack(){
+    console.log(this.context)
+    const { goBack } = this.props.history;
+    goBack();
+  }
+  render() {
+    const { transaction, inflow } = this.props;
+    const amount = formatAmount(transaction.value);
+    const amountCls = amount.isNegative ? styles.neg : styles.pos;
+    const itemPercentage = this.getItemPercentage(transaction.value);
+
+    const data = [
+      {index: "1", value: (100-itemPercentage).toFixed(2), name: "Total Budget"},
+      {index: "2", value: itemPercentage.toFixed(2), name: transaction.description },
+    ];
+    return (
+      <div>
+        <NavLink to="/budget" label="Go Back" styles={styles} />
+        <div className={styles.headerContent}>{transaction.description}</div>
+        <div className={amountCls}>
+          <div className={styles.cellContent}>{amount.text}</div>
+        </div>
+        <DonutChart data={data} valueFormat={value => formatToPercentage(value).text} dataLabel="name" dataKey="index"/>
+      </div>
+    );
+  }
+
+  getItemPercentage(itemValue) {
+    const { workingBalance } = this.props;
+    return (Math.abs(Number(itemValue))/Number(Math.abs(workingBalance)))*100;
+  }
+}
+
+const mapStateToProps = (state, props) => {
+  return {
+    transaction: getTransaction(getTransactions(state), Number(props.itemId)),
+    workingBalance: getWorkingBalance(state),
+  };
+};
+export default connect(mapStateToProps)(BudgetItem);

--- a/app/containers/BudgetItem/style.scss
+++ b/app/containers/BudgetItem/style.scss
@@ -1,0 +1,29 @@
+@import 'theme/variables';
+
+.cellLabel {
+  display: none;
+
+  @media only screen and (max-width: $screen-small) {
+    display: flex;
+    align-items: center;
+    flex: 1;
+  }
+}
+
+.cellContent {
+  flex: 1;
+}
+
+.headerContent {
+  font-size: 25px;
+  font-weight: 500;
+  padding: 0px 0px 20px 0px;
+}
+
+.neg {
+  color: $red;
+}
+
+.pos {
+  color: $green;
+}

--- a/app/containers/Spending/index.js
+++ b/app/containers/Spending/index.js
@@ -14,7 +14,6 @@ type SpendingProps = {
 class Spending extends React.Component<SpendingProps> {
   render() {
     const { data } = this.props;
-
     return <DonutChart data={data} dataLabel="category" dataKey="categoryId" />;
   }
 }

--- a/app/routes/BudgetItem/index.js
+++ b/app/routes/BudgetItem/index.js
@@ -1,0 +1,12 @@
+import React, { Component } from 'react';
+import Chunk from 'components/Chunk';
+
+const loadBudgetItemContainer = () => import('containers/BudgetItem');
+
+class BudgetItem extends Component<{}> {
+  render() {
+    return <Chunk load={loadBudgetItemContainer} itemId={this.props.match.params.itemId} />;
+  }
+}
+
+export default BudgetItem;

--- a/app/selectors/transactions.js
+++ b/app/selectors/transactions.js
@@ -78,3 +78,11 @@ export const getOutflowByCategoryName = createSelector(getOutflowByCategory, get
 export const getInflowByCategoryName = createSelector(getInflowByCategory, getCategories, (trans, cat) =>
   applyCategoryName(trans, cat)
 );
+
+//Get transaction of the item
+export const getTransaction = (transactions: T[], itemId): T => {
+  return transactions.filter(transaction => transaction.id === itemId)[0]
+};
+
+//Get working balance of the budget
+export const getWorkingBalance = createSelector([getTransactions], transactions => totalTransactions(transactions));

--- a/app/utils/formatToPercentage.js
+++ b/app/utils/formatToPercentage.js
@@ -1,0 +1,12 @@
+// @flow
+
+export type FormattedValue = {
+  text: string,
+};
+
+//To display the value as a percentage
+export default function formatToPercentage(amount: number): FormattedValue {
+  return {
+    text: `${amount}%`,
+  };
+}


### PR DESCRIPTION
… is contributing with, so I can better understand statistics of my inflow or outflow items ]

## Proposed Changes

When I click on that item 

- Then I want to see a new page with a title corresponding to the item details 
- And route should be dynamic with item ID in it 
- And a subtitle under title should show percentage with red minus sign showing outflow, green plus sign for inflow 
- And a pie chart showing how much of the entire budget this item is contributing with should be on that page 
- And no other items from the budget should be on that pie chart 
- And there should be a back button to return back to the previous route 
- And the view should be mobile and desktop compatible 
- 

## Screenshot

...
<img width="1675" alt="screen shot 2018-03-05 at 4 22 06 am" src="https://user-images.githubusercontent.com/2233683/36951767-3a6526f8-202d-11e8-88cc-4e50743669b7.png">


## Checklist

* [x] Feature developed
* [x] Created/updated unit tests
* [x] Comments in code
* [ ] Documentation written
