### PR TITLE
[Feature] As a user, I want to see percentage of total budget an item is contributing with, so I can better understand statistics of my inflow or outflow items

### DIFF
--- a/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<tr>
+<tr
+  onClick={[Function]}
+>
   <td>
     <div
       className="cellLabel"

--- a/app/components/BudgetGridRow/__tests__/index-test.js
+++ b/app/components/BudgetGridRow/__tests__/index-test.js
@@ -15,6 +15,14 @@ it('renders correctly', () => {
     2: 'School',
   };
 
-  const tree = renderer.create(<BudgetGridRow transaction={mockTransaction} categories={mockCategories} />).toJSON();
+  const mockOnClick = () => {};
+
+  const tree = renderer.create(
+    <BudgetGridRow
+      transaction={mockTransaction}
+      categories={mockCategories}
+      onClick={mockOnClick}
+    />
+  ).toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -7,17 +7,17 @@ import styles from './style.scss';
 
 type BudgetGridRowProps = {
   transaction: Transaction,
-  categories: Categories,
+  categories: Categories
 };
 
-const BudgetGridRow = ({ transaction, categories }: BudgetGridRowProps) => {
+const BudgetGridRow = ({ transaction, categories, onClick }: BudgetGridRowProps) => {
   const amount = formatAmount(transaction.value);
   const amountCls = amount.isNegative ? styles.neg : styles.pos;
   const { id, categoryId, description } = transaction;
   const category = categories[categoryId];
 
   return (
-    <tr key={id}>
+    <tr key={id} onClick={onClick}>
       <td>
         <div className={styles.cellLabel}>Category</div>
         <div className={styles.cellContent}>{category}</div>

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -7,7 +7,8 @@ import styles from './style.scss';
 
 type BudgetGridRowProps = {
   transaction: Transaction,
-  categories: Categories
+  categories: Categories,
+  onClick: Function
 };
 
 const BudgetGridRow = ({ transaction, categories, onClick }: BudgetGridRowProps) => {

--- a/app/components/DonutChart/index.js
+++ b/app/components/DonutChart/index.js
@@ -18,7 +18,7 @@ type DonutChartProps = {
   dataValue: string,
   color: Function,
   height: number,
-  innerRatio: number
+  innerRatio: number,
 };
 
 class DonutChart extends React.Component<DonutChartProps> {
@@ -26,7 +26,7 @@ class DonutChart extends React.Component<DonutChartProps> {
     color: scaleOrdinal(randomScheme),
     height: 300,
     innerRatio: 4,
-    dataValue: 'value'
+    dataValue: 'value',
   };
 
   componentWillMount() {
@@ -86,10 +86,7 @@ class DonutChart extends React.Component<DonutChartProps> {
           ))}
         </Chart>
 
-        <Legend
-          color={colorFn}
-          {...{ data, dataValue, dataLabel, dataKey }}
-        />
+        <Legend color={colorFn} {...{ data, dataValue, dataLabel, dataKey }} />
       </div>
     );
   }

--- a/app/components/DonutChart/index.js
+++ b/app/components/DonutChart/index.js
@@ -18,8 +18,7 @@ type DonutChartProps = {
   dataValue: string,
   color: Function,
   height: number,
-  innerRatio: number,
-  showOne: boolean
+  innerRatio: number
 };
 
 class DonutChart extends React.Component<DonutChartProps> {
@@ -27,8 +26,7 @@ class DonutChart extends React.Component<DonutChartProps> {
     color: scaleOrdinal(randomScheme),
     height: 300,
     innerRatio: 4,
-    dataValue: 'value',
-    showOne: false
+    dataValue: 'value'
   };
 
   componentWillMount() {
@@ -72,7 +70,7 @@ class DonutChart extends React.Component<DonutChartProps> {
   };
 
   render() {
-    const { data, dataLabel, dataValue, dataKey, showOne } = this.props;
+    const { data, dataLabel, dataValue, dataKey } = this.props;
     const { outerRadius, pathArc, colorFn, boxLength, chartPadding } = this;
 
     return (
@@ -83,15 +81,15 @@ class DonutChart extends React.Component<DonutChartProps> {
           padding={chartPadding}
           transform={`translate(${outerRadius},${outerRadius})`}
         >
-          {showOne
-            ? <Path data={this.chart(data)[0]} index={0} fill={colorFn(0)} arcFn={pathArc} />
-            : this.chart(data).map((datum, index) => (
-                <Path data={datum} index={index} fill={colorFn(index)} arcFn={pathArc} key={datum.data[dataKey]} />
-              ))
-          }
+          {this.chart(data).map((datum, index) => (
+            <Path data={datum} index={index} fill={colorFn(index)} arcFn={pathArc} key={datum.data[dataKey]} />
+          ))}
         </Chart>
 
-          <Legend color={colorFn} {...{ showOne, data, dataValue, dataLabel, dataKey }} />
+        <Legend
+          color={colorFn}
+          {...{ data, dataValue, dataLabel, dataKey }}
+        />
       </div>
     );
   }

--- a/app/components/DonutChart/index.js
+++ b/app/components/DonutChart/index.js
@@ -19,7 +19,7 @@ type DonutChartProps = {
   color: Function,
   height: number,
   innerRatio: number,
-  showOne: Boolean
+  showOne: boolean
 };
 
 class DonutChart extends React.Component<DonutChartProps> {
@@ -91,7 +91,7 @@ class DonutChart extends React.Component<DonutChartProps> {
           }
         </Chart>
 
-        <Legend color={colorFn} {...{ data, dataValue, dataLabel, dataKey }} />
+          <Legend color={colorFn} {...{ showOne, data, dataValue, dataLabel, dataKey }} />
       </div>
     );
   }

--- a/app/components/DonutChart/index.js
+++ b/app/components/DonutChart/index.js
@@ -19,6 +19,7 @@ type DonutChartProps = {
   color: Function,
   height: number,
   innerRatio: number,
+  showOne: Boolean
 };
 
 class DonutChart extends React.Component<DonutChartProps> {
@@ -27,6 +28,7 @@ class DonutChart extends React.Component<DonutChartProps> {
     height: 300,
     innerRatio: 4,
     dataValue: 'value',
+    showOne: false
   };
 
   componentWillMount() {
@@ -70,7 +72,7 @@ class DonutChart extends React.Component<DonutChartProps> {
   };
 
   render() {
-    const { data, dataLabel, dataValue, dataKey } = this.props;
+    const { data, dataLabel, dataValue, dataKey, showOne } = this.props;
     const { outerRadius, pathArc, colorFn, boxLength, chartPadding } = this;
 
     return (
@@ -81,9 +83,12 @@ class DonutChart extends React.Component<DonutChartProps> {
           padding={chartPadding}
           transform={`translate(${outerRadius},${outerRadius})`}
         >
-          {this.chart(data).map((datum, index) => (
-            <Path data={datum} index={index} fill={colorFn(index)} arcFn={pathArc} key={datum.data[dataKey]} />
-          ))}
+          {showOne
+            ? <Path data={this.chart(data)[0]} index={0} fill={colorFn(0)} arcFn={pathArc} />
+            : this.chart(data).map((datum, index) => (
+                <Path data={datum} index={index} fill={colorFn(index)} arcFn={pathArc} key={datum.data[dataKey]} />
+              ))
+          }
         </Chart>
 
         <Legend color={colorFn} {...{ data, dataValue, dataLabel, dataKey }} />

--- a/app/components/Legend/index.js
+++ b/app/components/Legend/index.js
@@ -21,7 +21,7 @@ const Legend = ({ data, color, dataValue, dataLabel, dataKey, reverse }: LegendT
         color={color(idx)}
         key={`${item[dataKey]}-${Math.random()}`}
         label={item[dataLabel]}
-        value={item[dataValue]}
+        value={item.isNegative || item[dataValue] < 0 ? `-${item[dataValue]}` : item[dataValue]}
       />
     ))}
   </ul>

--- a/app/components/Legend/index.js
+++ b/app/components/Legend/index.js
@@ -12,12 +12,18 @@ type LegendType = {
   dataKey: string,
   color: Function,
   reverse: boolean,
+  showOne: boolean
 };
 
-const Legend = ({ data, color, dataValue, dataLabel, dataKey, reverse }: LegendType) => (
+const Legend = ({ showOne, data, color, dataValue, dataLabel, dataKey, reverse }: LegendType) => (
   <ul className={cx(styles.legend, { [styles.reverse]: reverse })}>
     {data.map((item, idx) => (
-      <LegendItem color={color(idx)} key={`${item[dataKey]}-${Math.random()}`} label={item[dataLabel]} value={item[dataValue]} />
+      <LegendItem
+        color={color(idx)}
+        key={`${item[dataKey]}-${Math.random()}`}
+        label={item[dataLabel]}
+        value={showOne && item.value < 0 ? item.value : item[dataValue]}
+      />
     ))}
   </ul>
 );

--- a/app/components/Legend/index.js
+++ b/app/components/Legend/index.js
@@ -11,7 +11,7 @@ type LegendType = {
   dataLabel: string,
   dataKey: string,
   color: Function,
-  reverse: boolean
+  reverse: boolean,
 };
 
 const Legend = ({ data, color, dataValue, dataLabel, dataKey, reverse }: LegendType) => (

--- a/app/components/Legend/index.js
+++ b/app/components/Legend/index.js
@@ -11,18 +11,17 @@ type LegendType = {
   dataLabel: string,
   dataKey: string,
   color: Function,
-  reverse: boolean,
-  showOne: boolean
+  reverse: boolean
 };
 
-const Legend = ({ showOne, data, color, dataValue, dataLabel, dataKey, reverse }: LegendType) => (
+const Legend = ({ data, color, dataValue, dataLabel, dataKey, reverse }: LegendType) => (
   <ul className={cx(styles.legend, { [styles.reverse]: reverse })}>
     {data.map((item, idx) => (
       <LegendItem
         color={color(idx)}
         key={`${item[dataKey]}-${Math.random()}`}
         label={item[dataLabel]}
-        value={showOne && item.value < 0 ? item.value : item[dataValue]}
+        value={item[dataValue]}
       />
     ))}
   </ul>

--- a/app/components/Legend/index.js
+++ b/app/components/Legend/index.js
@@ -17,7 +17,7 @@ type LegendType = {
 const Legend = ({ data, color, dataValue, dataLabel, dataKey, reverse }: LegendType) => (
   <ul className={cx(styles.legend, { [styles.reverse]: reverse })}>
     {data.map((item, idx) => (
-      <LegendItem color={color(idx)} key={item[dataKey]} label={item[dataLabel]} value={item[dataValue]} />
+      <LegendItem color={color(idx)} key={`${item[dataKey]}-${Math.random()}`} label={item[dataLabel]} value={item[dataValue]} />
     ))}
   </ul>
 );

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -17,7 +17,7 @@ const App = () => (
 
       <Switch>
         <Route path="/budget" component={Budget} exact />
-        <Route path="/budget/:id" component={BudgetDetails} />
+        <Route path="/budget/:transactionId" component={BudgetDetails} />
         <Route path="/reports" component={Reports} />
         <Redirect to="/budget" />
       </Switch>

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -7,6 +7,7 @@ import AppError from 'components/AppError';
 import Header from 'components/Header';
 import Budget from 'routes/Budget';
 import Reports from 'routes/Reports';
+import BudgetDetails from 'routes/BudgetDetails';
 import './style.scss';
 
 const App = () => (
@@ -15,7 +16,8 @@ const App = () => (
       <Header />
 
       <Switch>
-        <Route path="/budget" component={Budget} />
+        <Route path="/budget" component={Budget} exact />
+        <Route path="/budget/:id" component={BudgetDetails} />
         <Route path="/reports" component={Reports} />
         <Redirect to="/budget" />
       </Switch>

--- a/app/containers/BudgetDetails/__tests__/__snapshots__/index.test.js.snap
+++ b/app/containers/BudgetDetails/__tests__/__snapshots__/index.test.js.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders correctly 1`] = `
+exports[`should render 1`] = `
 <div>
   <h1>
-    Gas
+    Trader Joe's food
   </h1>
   <h2
     className="neg"
   >
     -
-    100
+    9
     %
   </h2>
   <button

--- a/app/containers/BudgetDetails/__tests__/__snapshots__/index.test.js.snap
+++ b/app/containers/BudgetDetails/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<div>
+  <h1>
+    Gas
+  </h1>
+  <h2
+    className="neg"
+  >
+    -
+    100
+    %
+  </h2>
+  <button
+    onClick={[Function]}
+  >
+    Go Back
+  </button>
+</div>
+`;

--- a/app/containers/BudgetDetails/__tests__/index.test.js
+++ b/app/containers/BudgetDetails/__tests__/index.test.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { BudgetDetails } from '../';
+
+// mock nested component
+jest.mock('components/DonutChart');
+
+it('renders correctly', () => {
+  const mockTransaction = {
+    catgeoryId: "6",
+    description: "Gas",
+    id: 2,
+    value: -764.73
+  };
+  const mockTransactions = [mockTransaction];
+
+  const tree = renderer.create(
+    <BudgetDetails
+      transactions={mockTransactions}
+      selectedTransaction={mockTransaction}
+    />
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/containers/BudgetDetails/__tests__/index.test.js
+++ b/app/containers/BudgetDetails/__tests__/index.test.js
@@ -1,18 +1,30 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { BudgetDetails } from '../';
+import { BudgetDetails, mapStateToProps } from '../';
+import { categoriesById, defaultTransactions } from 'modules/defaults';
 
 // mock nested component
 jest.mock('components/DonutChart');
 
-it('renders correctly', () => {
-  const mockTransaction = {
-    catgeoryId: "6",
-    description: "Gas",
-    id: 2,
-    value: -764.73
+it('mapStateToProps should return empty object if params not found', () => {
+  const mockState = {
+    categories: { ...categoriesById },
+    transactions: defaultTransactions.slice()
   };
-  const mockTransactions = [mockTransaction];
+  const mockProps = {
+    match: {}
+  };
+  const finalProps = {
+    selectedTransaction: '',
+    transactions: defaultTransactions.slice()
+  };
+
+  expect(mapStateToProps(mockState, mockProps)).toEqual(finalProps)
+});
+
+it ('should render', () => {
+  const mockTransactions = defaultTransactions.slice();
+  const mockTransaction = mockTransactions[0]
 
   const tree = renderer.create(
     <BudgetDetails
@@ -20,5 +32,7 @@ it('renders correctly', () => {
       selectedTransaction={mockTransaction}
     />
   ).toJSON();
+
   expect(tree).toMatchSnapshot();
+
 });

--- a/app/containers/BudgetDetails/index.js
+++ b/app/containers/BudgetDetails/index.js
@@ -3,6 +3,9 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { getTransactions } from 'selectors/transactions';
 import { getCategories } from 'selectors/categories';
+import DonutChart from 'components/DonutChart';
+
+import styles from 'components/BudgetGridRow/style.scss';
 
 type BudgetDetailsProps = {
   transactions: Transaction[],
@@ -26,21 +29,46 @@ export class BudgetDetails extends React.Component<BudgetDetailsProps> {
     }
   }
 
+  serializeData = () => {
+
+  }
+
   render() {
-    const { selectedTransaction, categories } = this.props;
-    console.log('selectedTransaction: ', selectedTransaction);
-    const category = categories[Object.keys(categories).find(categoryId => categoryId === selectedTransaction.categoryId)];
-    console.log('category: ', category);
+    const { transactions, selectedTransaction, categories } = this.props;
 
     if (Object.keys(selectedTransaction).length === 0) {
       return null;
     }
 
+    const category = categories[Object.keys(categories).find(categoryId => categoryId === selectedTransaction.categoryId)];
+    const percentageTextStyles = selectedTransaction.value < 0 ? styles.neg : styles.pos;
+
+    const absTotal = transactions.reduce((prev, next) => {
+      return prev + Math.abs(next.value);
+    }, 0);
+    const percentageAmount = Math.floor(
+      Math.abs(selectedTransaction.value) / absTotal * 100
+    );
+
+    const newTransactions = [selectedTransaction].concat(
+      transactions.filter(transaction => transaction.id !== selectedTransaction.id)
+    ).map(transaction => ({
+      ...transaction,
+      value: Math.abs(transaction.value)
+    }))
+
     return (
       <div>
         <h1>{selectedTransaction.description}</h1>
 
-        <p>{selectedTransaction.value}</p>
+        <div className={percentageTextStyles}>{percentageAmount}%</div>
+
+        <DonutChart
+          showOne
+          data={newTransactions}
+          dataLabel="category"
+          dataKey="categoryId"
+        />
       </div>
     );
   }

--- a/app/containers/BudgetDetails/index.js
+++ b/app/containers/BudgetDetails/index.js
@@ -110,7 +110,7 @@ export class BudgetDetails extends React.Component<BudgetDetailsProps> {
   }
 }
 
-const mapStateToProps = (state, ownProps) => {
+export const mapStateToProps = (state, ownProps) => {
   const transactions = getTransactions(state);
   let transactionId = '';
   let selectedTransaction = '';

--- a/app/containers/BudgetDetails/index.js
+++ b/app/containers/BudgetDetails/index.js
@@ -19,7 +19,8 @@ export class BudgetDetails extends React.Component<BudgetDetailsProps> {
   };
 
   componentWillMount() {
-    const { transactions, match: { params: { transactionId } } } = this.props;
+    const { transactions, match } = this.props;
+    const transactionId = match && match.params ? match.params.transactionId : '';
 
     // go back to BudgetTable if data not available
     if (!transactionId ||
@@ -31,6 +32,10 @@ export class BudgetDetails extends React.Component<BudgetDetailsProps> {
 
   serializeData = () => {
     const { selectedTransaction, transactions } = this.props;
+
+    if (!transactions && transactions.length) {
+      return [];
+    }
 
     let absTotal = selectedTransaction.value;
     const isNegative = Boolean(selectedTransaction.value < 0)
@@ -66,8 +71,11 @@ export class BudgetDetails extends React.Component<BudgetDetailsProps> {
     return [serializedSelectedTransaction, otherTransactions]
   }
 
-  navigateToBudget = () =>
-    this.props.history.push('/budget')
+  navigateToBudget = () => {
+    if (this.props.history) {
+      this.props.history.push('/budget')
+    }
+  }
 
   render() {
     const selectedTransaction = this.props.selectedTransaction;
@@ -78,15 +86,16 @@ export class BudgetDetails extends React.Component<BudgetDetailsProps> {
 
     // returns array of 2 items, [selected, expenses/income]
     const donutData = this.serializeData();
+    const currentItem = donutData[0];
     // styles to show red or green
-    const percentageTextStyles = donutData[0].isNegative ? styles.neg : styles.pos;
+    const percentageTextStyles = currentItem.isNegative ? styles.neg : styles.pos;
 
     return (
       <div>
-        <h1>{donutData[0].description}</h1>
+        <h1>{currentItem.description}</h1>
 
         <h2 className={percentageTextStyles}>
-          {donutData[0].isNegative ? '-' : '+'} {donutData[0].percentage}%
+          {currentItem.isNegative ? '-' : '+'}{currentItem.percentage}%
         </h2>
 
         <DonutChart
@@ -103,8 +112,12 @@ export class BudgetDetails extends React.Component<BudgetDetailsProps> {
 
 const mapStateToProps = (state, ownProps) => {
   const transactions = getTransactions(state);
-  const transactionId = ownProps.match.params.transactionId;
-  const selectedTransaction = transactions.find(transaction => transaction.id === Number(transactionId));
+  let transactionId = '';
+  let selectedTransaction = '';
+  if (ownProps.match && ownProps.match.params) {
+    transactionId = ownProps.match.params.transactionId;
+    selectedTransaction = transactions.find(transaction => transaction.id === Number(transactionId));
+  }
 
   return {
     selectedTransaction,

--- a/app/containers/BudgetDetails/index.js
+++ b/app/containers/BudgetDetails/index.js
@@ -40,25 +40,29 @@ export class BudgetDetails extends React.Component<BudgetDetailsProps> {
     let absTotal = selectedTransaction.value;
     const isNegative = Boolean(selectedTransaction.value < 0)
 
+    // to be consumed by DonutChart & Legend - must conform to schema
+    const otherTransactionSchema = {
+      id: Math.random(),
+      isNegative,
+      description: isNegative ? 'Other Expenses' : 'Other Income',
+      value: 0
+    }
+
     const otherTransactions = transactions
-      .filter(_ => _.id !== selectedTransaction.id)
-      .filter(_ => isNegative
+      .filter(_ => _.id !== selectedTransaction.id)   // remove selected transaction
+      .filter(_ => isNegative   // only want Expense or Income transactions
         ? _.value < 0
         : _.value >= 0
       )
       .reduce((prev, next) => {
-        absTotal += next.value;
+        absTotal += next.value;   // sum the rest of the Expenses or Incomes into a single value
         return {
           ...prev,
-          value: prev.value + Math.abs(next.value)
+          value: prev.value + Math.abs(next.value)    // sum the rest of the Expenses or Incomes into a single value
         }
-      }, {
-        id: Math.random(),
-        isNegative,
-        description: isNegative ? 'Other Expenses' : 'Other Income',
-        value: 0
-      })
+      }, otherTransactionSchema)
 
+    // update existing transaction, add extra flags for Legend display
     const serializedSelectedTransaction = {
       ...selectedTransaction,
       isNegative,

--- a/app/containers/BudgetDetails/index.js
+++ b/app/containers/BudgetDetails/index.js
@@ -25,13 +25,16 @@ export class BudgetDetails extends React.Component<BudgetDetailsProps> {
     if (!transactionId ||
       transactionId && !transactions.length
     ) {
-      history.push('/budget');
+      this.navigateToBudget();
     }
   }
 
   serializeData = () => {
 
   }
+
+  navigateToBudget = () =>
+    this.props.history.push('/budget')
 
   render() {
     const { transactions, selectedTransaction, categories } = this.props;
@@ -54,21 +57,28 @@ export class BudgetDetails extends React.Component<BudgetDetailsProps> {
       transactions.filter(transaction => transaction.id !== selectedTransaction.id)
     ).map(transaction => ({
       ...transaction,
-      value: Math.abs(transaction.value)
+      absValue: Math.abs(transaction.value)
     }))
+    console.log('selectedTransaction: ', selectedTransaction);
+    console.log('newTransactions: ', newTransactions);
 
     return (
       <div>
         <h1>{selectedTransaction.description}</h1>
 
-        <div className={percentageTextStyles}>{percentageAmount}%</div>
+        <div className={percentageTextStyles}>
+          {selectedTransaction.value < 0 ? '-' : '+'} {percentageAmount}%
+        </div>
 
         <DonutChart
           showOne
           data={newTransactions}
-          dataLabel="category"
-          dataKey="categoryId"
+          dataLabel="description"
+          dataKey="description"
+          dataValue="absValue"
         />
+
+        <button onClick={this.navigateToBudget}>Go Back</button>
       </div>
     );
   }

--- a/app/containers/BudgetDetails/index.js
+++ b/app/containers/BudgetDetails/index.js
@@ -45,10 +45,11 @@ export class BudgetDetails extends React.Component<BudgetDetailsProps> {
         absTotal += next.value;
         return {
           ...prev,
-          value: prev.value + next.value
+          value: prev.value + Math.abs(next.value)
         }
       }, {
         id: Math.random(),
+        isNegative,
         description: isNegative ? 'Other Expenses' : 'Other Income',
         value: 0
       })
@@ -56,6 +57,7 @@ export class BudgetDetails extends React.Component<BudgetDetailsProps> {
     const serializedSelectedTransaction = {
       ...selectedTransaction,
       isNegative,
+      value: Math.abs(selectedTransaction.value),
       percentage: Math.floor(
         selectedTransaction.value / absTotal * 100
       ),

--- a/app/containers/BudgetDetails/index.js
+++ b/app/containers/BudgetDetails/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+
+const BudgetDetails = props =>
+  <div>hello world</div>;
+
+export default BudgetDetails;

--- a/app/containers/BudgetDetails/index.js
+++ b/app/containers/BudgetDetails/index.js
@@ -1,6 +1,63 @@
 import React from 'react';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import { getTransactions } from 'selectors/transactions';
+import { getCategories } from 'selectors/categories';
 
-const BudgetDetails = props =>
-  <div>hello world</div>;
+type BudgetDetailsProps = {
+  transactions: Transaction[],
+  categories: Object,
+  selectedTransaction: Transaction,
+};
 
-export default BudgetDetails;
+export class BudgetDetails extends React.Component<BudgetDetailsProps> {
+  static defaultProps = {
+    transactions: [],
+    selectedTransaction: {}
+  };
+
+  componentWillMount() {
+    const { transactions, history, match: { params: { transactionId } } } = this.props;
+
+    if (!transactionId ||
+      transactionId && !transactions.length
+    ) {
+      history.push('/budget');
+    }
+  }
+
+  render() {
+    const { selectedTransaction, categories } = this.props;
+    console.log('selectedTransaction: ', selectedTransaction);
+    const category = categories[Object.keys(categories).find(categoryId => categoryId === selectedTransaction.categoryId)];
+    console.log('category: ', category);
+
+    if (Object.keys(selectedTransaction).length === 0) {
+      return null;
+    }
+
+    return (
+      <div>
+        <h1>{selectedTransaction.description}</h1>
+
+        <p>{selectedTransaction.value}</p>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = (state, ownProps) => {
+  const transactions = getTransactions(state);
+  const transactionId = ownProps.match.params.transactionId;
+  const selectedTransaction = transactions.find(transaction => transaction.id === Number(transactionId));
+
+  return {
+    categories: getCategories(state),
+    selectedTransaction,
+    transactions,
+  };
+};
+
+export default withRouter(
+  connect(mapStateToProps)(BudgetDetails)
+);

--- a/app/containers/BudgetGrid/__tests__/index-test.js
+++ b/app/containers/BudgetGrid/__tests__/index-test.js
@@ -1,11 +1,23 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { BudgetGrid } from '../index';
+import { MemoryRouter } from 'react-router-dom';
 
 // mock nested component
+jest.mock('components/BudgetGridRow');
 jest.mock('containers/EntryFormRow');
 
 it('renders correctly', () => {
   const tree = renderer.create(<BudgetGrid />).toJSON();
+
   expect(tree).toMatchSnapshot();
 });
+
+it ('navigate to destination', () => {
+  const mockHistory = {
+    push: testId => testId
+  }
+  const tree = renderer.create(<BudgetGrid history={mockHistory} />);
+
+  expect(tree.getInstance().navigateToDetailsPage('123')).toEqual('/budget/123')
+})

--- a/app/containers/BudgetGrid/index.js
+++ b/app/containers/BudgetGrid/index.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { getTransactions } from 'selectors/transactions';
+import { withRouter } from 'react-router-dom';
 import { getCategories } from 'selectors/categories';
 import EntryFormRow from 'containers/EntryFormRow';
 import type { Transaction } from 'modules/transactions';
@@ -19,6 +20,9 @@ export class BudgetGrid extends React.Component<BudgetGridProps> {
     categories: {},
   };
 
+  navigateToDetailsPage = transactionId =>
+    this.props.history.push(`/budget/${transactionId}`)
+
   render() {
     const { transactions, categories } = this.props;
 
@@ -33,7 +37,12 @@ export class BudgetGrid extends React.Component<BudgetGridProps> {
         </thead>
         <tbody>
           {transactions.map((transaction: Transaction): React.Element<any> => (
-            <BudgetGridRow key={transaction.id} transaction={transaction} categories={categories} />
+            <BudgetGridRow
+              key={transaction.id}
+              transaction={transaction}
+              categories={categories}
+              onClick={() => this.navigateToDetailsPage(transaction.id)}
+            />
           ))}
         </tbody>
         <tfoot>
@@ -49,4 +58,6 @@ const mapStateToProps = state => ({
   categories: getCategories(state),
 });
 
-export default connect(mapStateToProps)(BudgetGrid);
+export default withRouter(
+  connect(mapStateToProps)(BudgetGrid)
+);

--- a/app/containers/BudgetGrid/index.js
+++ b/app/containers/BudgetGrid/index.js
@@ -1,8 +1,8 @@
 // @flow
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { getTransactions } from 'selectors/transactions';
 import { withRouter } from 'react-router-dom';
+import { getTransactions } from 'selectors/transactions';
 import { getCategories } from 'selectors/categories';
 import EntryFormRow from 'containers/EntryFormRow';
 import type { Transaction } from 'modules/transactions';
@@ -25,6 +25,9 @@ export class BudgetGrid extends React.Component<BudgetGridProps> {
 
   render() {
     const { transactions, categories } = this.props;
+
+    console.log('transactions: ', transactions);
+    console.log('categories: ', categories);
 
     return (
       <table className={styles.budgetGrid}>

--- a/app/containers/BudgetGrid/index.js
+++ b/app/containers/BudgetGrid/index.js
@@ -26,9 +26,6 @@ export class BudgetGrid extends React.Component<BudgetGridProps> {
   render() {
     const { transactions, categories } = this.props;
 
-    console.log('transactions: ', transactions);
-    console.log('categories: ', categories);
-
     return (
       <table className={styles.budgetGrid}>
         <thead>

--- a/app/containers/BudgetGrid/style.scss
+++ b/app/containers/BudgetGrid/style.scss
@@ -16,6 +16,14 @@
     padding: 8px;
   }
 
+  tbody tr {
+    cursor: pointer;
+
+    &:hover {
+      background-color: #E4F6F8;
+    }
+  }
+
   th, td {
     text-align: left;
     overflow: hidden;

--- a/app/routes/BudgetDetails/index.js
+++ b/app/routes/BudgetDetails/index.js
@@ -1,0 +1,12 @@
+import React, { Component } from 'react';
+import Chunk from 'components/Chunk';
+
+const loadBudgetDetailsContainer = () => import('containers/BudgetDetails' /* webpackChunkName: "budget" */);
+
+class BudgetDetails extends Component<{}> {
+  render() {
+    return <Chunk load={loadBudgetDetailsContainer} />;
+  }
+}
+
+export default BudgetDetails;


### PR DESCRIPTION
## Feature

As a user, I want to see percentage of total budget an item is contributing with, so I can better understand statistics of my inflow or outflow items

## Proposed Changes

- Given that I have added at least one item to the budgeting grid 
- When I click on that item 
- Then I want to see a new page with a title corresponding to the item details 
- And route should be dynamic with item ID in it
- And a subtitle under title should show percentage with red minus sign showing outflow, green plus sign for inflow
- And a pie chart showing how much of the entire budget this item is contributing with should be on that page
- And no other items from the budget should be on that pie chart
- And there should be a back button to return back to the previous route
- And the view should be mobile and desktop compatible
 
## Screenshot

![screen shot 2018-03-10 at 12 50 31 pm](https://user-images.githubusercontent.com/11435329/37245993-1cde9420-246f-11e8-9f87-8dab1247ecaf.png)

## Checklist

* [x] Feature developed
* [x] Created/updated unit tests
* [x] Comments in code
* [ ] Documentation written
