### PR TITLE
Feature: Percentage of total budget an item is contributing with.

### DIFF
--- a/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
@@ -23,7 +23,11 @@ exports[`renders correctly 1`] = `
     <div
       className="cellContent"
     >
-      Trader Joe's food
+      <a
+        href="/transaction/1"
+      >
+        Trader Joe's food
+      </a>
     </div>
   </td>
   <td

--- a/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<tr>
+<tr
+  className="row"
+>
   <td>
     <div
       className="cellLabel"

--- a/app/components/BudgetGridRow/__tests__/index-test.js
+++ b/app/components/BudgetGridRow/__tests__/index-test.js
@@ -2,6 +2,9 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import BudgetGridRow from 'components/BudgetGridRow';
 
+// mock nested component
+jest.mock('components/NavLink', () => ({ to, label }) => <a href={to}>{label}</a>);
+
 it('renders correctly', () => {
   const mockTransaction = {
     id: 1,

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -18,7 +18,7 @@ const BudgetGridRow = ({ transaction, categories }: BudgetGridRowProps) => {
   const category = categories[categoryId];
 
   return (
-    <tr key={id}>
+    <tr key={id} className={styles.row}>
       <td>
         <div className={styles.cellLabel}>Category</div>
         <div className={styles.cellContent}>{category}</div>
@@ -26,7 +26,7 @@ const BudgetGridRow = ({ transaction, categories }: BudgetGridRowProps) => {
       <td>
         <div className={styles.cellLabel}>Description</div>
         <div className={styles.cellContent}>
-          <NavLink to={`/transaction/${id}`} label={description} styles={{}} />
+          <NavLink to={`/transaction/${id}`} label={description} styles={styles} />
         </div>
       </td>
       <td className={amountCls}>

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import formatAmount from 'utils/formatAmount';
+import NavLink from 'components/NavLink';
 import type { Transaction } from 'modules/transactions';
 import type { Categories } from 'modules/categories';
 import styles from './style.scss';
@@ -24,7 +25,9 @@ const BudgetGridRow = ({ transaction, categories }: BudgetGridRowProps) => {
       </td>
       <td>
         <div className={styles.cellLabel}>Description</div>
-        <div className={styles.cellContent}>{description}</div>
+        <div className={styles.cellContent}>
+          <NavLink to={`/transaction/${id}`} label={description} styles={{}} />
+        </div>
       </td>
       <td className={amountCls}>
         <div className={styles.cellLabel}>Amount</div>

--- a/app/components/BudgetGridRow/style.scss
+++ b/app/components/BudgetGridRow/style.scss
@@ -1,5 +1,9 @@
 @import 'theme/variables';
 
+.row {
+  position: relative;
+}
+
 .cellLabel {
   display: none;
 
@@ -12,6 +16,25 @@
 
 .cellContent {
   flex: 1;
+}
+
+.navLink {
+
+  &:hover {
+    text-decoration: none;
+  }
+
+  @media only screen and (max-width: $screen-small) {
+    &::before {
+      display: block;
+      content: '';
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+    }
+  }
 }
 
 .neg {

--- a/app/components/Transaction/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/Transaction/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<article>
+  <h1
+    className="title"
+  >
+    Trader Joe's food
+  </h1>
+  <h2
+    className="negative"
+  >
+    -
+    100%
+  </h2>
+  <div />
+</article>
+`;

--- a/app/components/Transaction/__tests__/index-test.js
+++ b/app/components/Transaction/__tests__/index-test.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import Transaction from 'components/Transaction';
+
+// mock nested component
+jest.mock('components/DonutChart', () => () => <div />);
+
+it('renders correctly', () => {
+  const mockTransaction = {
+    id: 1,
+    description: "Trader Joe's food",
+    value: -423.34,
+    categoryId: 1,
+  };
+
+  const balance = 423.34;
+
+  const tree = renderer.create(<Transaction balance={balance} {...mockTransaction} />).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/components/Transaction/index.js
+++ b/app/components/Transaction/index.js
@@ -1,0 +1,6 @@
+// @flow
+import * as React from 'react';
+
+const Transaction = ({ description }) => <h1>{description}</h1>;
+
+export default Transaction;

--- a/app/components/Transaction/index.js
+++ b/app/components/Transaction/index.js
@@ -33,7 +33,7 @@ const Transaction = ({ id, description, value, balance }: TransactionComponentPr
   const color = scaleLinear().range(scheme);
 
   return (
-    <React.Fragment>
+    <article>
       <h1 className={styles.title}>{description}</h1>
       <h2 className={`${isNegative ? styles.negative : styles.positive}`}>
         {sign}
@@ -48,7 +48,7 @@ const Transaction = ({ id, description, value, balance }: TransactionComponentPr
         // We use inifnity to achieve the pie chart.
         innerRatio={Infinity}
       />
-    </React.Fragment>
+    </article>
   );
 };
 

--- a/app/components/Transaction/index.js
+++ b/app/components/Transaction/index.js
@@ -8,7 +8,7 @@ import styles from './style.scss';
 
 type TransactionComponentProps = {
   ...TransactionProps,
-  balance: number,
+  +balance: number,
 };
 
 const Transaction = ({ id, description, value, balance }: TransactionComponentProps) => {

--- a/app/components/Transaction/index.js
+++ b/app/components/Transaction/index.js
@@ -1,6 +1,44 @@
 // @flow
 import * as React from 'react';
+import { scaleLinear } from 'd3';
+import formatAmount from 'utils/formatAmount';
+import DonutChart from 'components/DonutChart';
+import styles from './style.scss';
 
-const Transaction = ({ description }) => <h1>{description}</h1>;
+const Transaction = ({ id, description, value, balance }) => {
+  const amount = Math.abs(value);
+  const percentage = formatAmount(amount / balance, false, 'percent');
+
+  const isNegative = value < 0;
+  const sign = isNegative ? '-' : '+';
+
+  const balanceLabel = isNegative ? 'Expenses' : 'Incomes';
+  const chartData = [
+    { id, description, amount },
+    { id: Infinity, description: `Other ${balanceLabel}`, amount: balance - amount },
+  ];
+
+  // Set the color scheme for the chart based on the type of transaction.
+  const scheme = [isNegative ? 'red' : 'green', 'ivory'];
+  const color = scaleLinear().range(scheme);
+
+  return (
+    <React.Fragment>
+      <h1 className={styles.title}>{description}</h1>
+      <h2 className={`${isNegative ? styles.negative : styles.positive}`}>
+        {sign}
+        {percentage.text}
+      </h2>
+      <DonutChart
+        data={chartData}
+        dataKey="id"
+        dataLabel="description"
+        dataValue="amount"
+        color={color}
+        innerRatio={Infinity}
+      />
+    </React.Fragment>
+  );
+};
 
 export default Transaction;

--- a/app/components/Transaction/index.js
+++ b/app/components/Transaction/index.js
@@ -1,20 +1,30 @@
 // @flow
 import * as React from 'react';
 import { scaleLinear } from 'd3';
+import type { Transaction as TransactionProps } from 'modules/transactions';
 import formatAmount from 'utils/formatAmount';
 import DonutChart from 'components/DonutChart';
 import styles from './style.scss';
 
-const Transaction = ({ id, description, value, balance }) => {
+type TransactionComponentProps = {
+  ...TransactionProps,
+  balance: number,
+};
+
+const Transaction = ({ id, description, value, balance }: TransactionComponentProps) => {
   const amount = Math.abs(value);
+  // Calculate the percentage of transaction related to the balance.
   const percentage = formatAmount(amount / balance, false, 'percent');
 
   const isNegative = value < 0;
   const sign = isNegative ? '-' : '+';
 
   const balanceLabel = isNegative ? 'Expenses' : 'Incomes';
+  // The chart is composed of two values:
   const chartData = [
+    // The current transaction item.
     { id, description, amount },
+    // And everything else of the same type (inflows/outflows).
     { id: Infinity, description: `Other ${balanceLabel}`, amount: balance - amount },
   ];
 
@@ -35,6 +45,7 @@ const Transaction = ({ id, description, value, balance }) => {
         dataLabel="description"
         dataValue="amount"
         color={color}
+        // We use inifnity to achieve the pie chart.
         innerRatio={Infinity}
       />
     </React.Fragment>

--- a/app/components/Transaction/style.scss
+++ b/app/components/Transaction/style.scss
@@ -1,0 +1,13 @@
+@import 'theme/variables';
+
+.title {
+  margin-bottom: 0;
+}
+
+.negative {
+  color: $red;
+}
+
+.positive {
+  color: $green;
+}

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -6,6 +6,7 @@ import ErrorBoundary from 'components/ErrorBoundary';
 import AppError from 'components/AppError';
 import Header from 'components/Header';
 import Budget from 'routes/Budget';
+import Transaction from 'routes/Transaction';
 import Reports from 'routes/Reports';
 import './style.scss';
 
@@ -15,6 +16,7 @@ const App = () => (
       <Header />
 
       <Switch>
+        <Route path="/transaction/:id" component={Transaction} />
         <Route path="/budget" component={Budget} />
         <Route path="/reports" component={Reports} />
         <Redirect to="/budget" />

--- a/app/containers/Transaction/__tests__/__snapshots__/index.test.js.snap
+++ b/app/containers/Transaction/__tests__/__snapshots__/index.test.js.snap
@@ -7,13 +7,13 @@ exports[`renders correctly 1`] = `
   >
     ← Budget
   </a>
-  <section>
+  <article>
     <h1>
       Test
     </h1>
     <h2>
       10
     </h2>
-  </section>
+  </article>
 </section>
 `;

--- a/app/containers/Transaction/__tests__/__snapshots__/index.test.js.snap
+++ b/app/containers/Transaction/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<section>
+  <a
+    href="/budget"
+  >
+    ← Budget
+  </a>
+  <section>
+    <h1>
+      Test
+    </h1>
+    <h2>
+      10
+    </h2>
+  </section>
+</section>
+`;

--- a/app/containers/Transaction/__tests__/index.test.js
+++ b/app/containers/Transaction/__tests__/index.test.js
@@ -6,10 +6,10 @@ import { Transaction } from '../index';
 // mock nested component
 jest.mock('components/NavLink', () => ({ to, label }) => <a href={to}>{label}</a>);
 jest.mock('components/Transaction', () => ({ description, value }) => (
-  <section>
+  <article>
     <h1>{description}</h1>
     <h2>{value}</h2>
-  </section>
+  </article>
 ));
 
 it('renders correctly', () => {

--- a/app/containers/Transaction/__tests__/index.test.js
+++ b/app/containers/Transaction/__tests__/index.test.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { MemoryRouter } from 'react-router-dom';
+import { Transaction } from '../index';
+
+// mock nested component
+jest.mock('components/NavLink', () => ({ to, label }) => <a href={to}>{label}</a>);
+jest.mock('components/Transaction', () => ({ description, value }) => (
+  <section>
+    <h1>{description}</h1>
+    <h2>{value}</h2>
+  </section>
+));
+
+it('renders correctly', () => {
+  const tree = renderer
+    .create(
+      <MemoryRouter>
+        <Transaction transaction={{ description: 'Test', value: 10 }} balance={10} />
+      </MemoryRouter>
+    )
+    .toJSON();
+
+  expect(tree).toMatchSnapshot();
+});

--- a/app/containers/Transaction/index.js
+++ b/app/containers/Transaction/index.js
@@ -1,0 +1,6 @@
+// @flow
+import * as React from 'react';
+
+const Transaction = ({ transaction }) => <section>Transaction: {transaction}</section>;
+
+export default Transaction;

--- a/app/containers/Transaction/index.js
+++ b/app/containers/Transaction/index.js
@@ -13,7 +13,7 @@ injectAsyncReducers({
   transactions: transactionReducer,
 });
 
-const Transaction = ({ transaction, balance }) => {
+export const Transaction = ({ transaction, balance }) => {
   // If no transaction with a matching ID was found, redirect to budget.
   if (!transaction) return <Redirect to="/budget" />;
 

--- a/app/containers/Transaction/index.js
+++ b/app/containers/Transaction/index.js
@@ -10,9 +10,9 @@ import NavLink from 'components/NavLink';
 import TransactionItem from 'components/Transaction';
 
 type TransactionContainerProps = {
-  id: number,
-  balance: number,
-  transaction: TransactionProps,
+  +id: number,
+  +balance: number,
+  +transaction: ?TransactionProps,
 };
 
 // inject reducers that might not have been originally there

--- a/app/containers/Transaction/index.js
+++ b/app/containers/Transaction/index.js
@@ -1,6 +1,27 @@
 // @flow
 import * as React from 'react';
+import { connect } from 'react-redux';
+import { getTransaction } from 'selectors/transactions';
+import { injectAsyncReducers } from 'store';
+import { Redirect } from 'react-router-dom';
+import transactionReducer from 'modules/transactions';
+import NavLink from 'components/NavLink';
+import TransactionItem from 'components/Transaction';
 
-const Transaction = ({ transaction }) => <section>Transaction: {transaction}</section>;
+// inject reducers that might not have been originally there
+injectAsyncReducers({
+  transactions: transactionReducer,
+});
 
-export default Transaction;
+const Transaction = ({ transaction }) => (
+  <section>
+    <NavLink to="/budget" label="← Budget" styles={{}} />
+    {transaction ? <TransactionItem {...transaction} /> : <Redirect to="/budget" />}
+  </section>
+);
+
+const mapStateToProps = (state, props) => ({
+  transaction: getTransaction(state, props.id),
+});
+
+export default connect(mapStateToProps)(Transaction);

--- a/app/containers/Transaction/index.js
+++ b/app/containers/Transaction/index.js
@@ -4,16 +4,23 @@ import { connect } from 'react-redux';
 import { Redirect } from 'react-router-dom';
 import { getTransaction, getTransactionBalance } from 'selectors/transactions';
 import { injectAsyncReducers } from 'store';
+import type { Transaction as TransactionProps } from 'modules/transactions';
 import transactionReducer from 'modules/transactions';
 import NavLink from 'components/NavLink';
 import TransactionItem from 'components/Transaction';
+
+type TransactionContainerProps = {
+  id: number,
+  balance: number,
+  transaction: TransactionProps,
+};
 
 // inject reducers that might not have been originally there
 injectAsyncReducers({
   transactions: transactionReducer,
 });
 
-export const Transaction = ({ transaction, balance }) => {
+export const Transaction = ({ transaction, balance }: TransactionContainerProps) => {
   // If no transaction with a matching ID was found, redirect to budget.
   if (!transaction) return <Redirect to="/budget" />;
 

--- a/app/containers/Transaction/index.js
+++ b/app/containers/Transaction/index.js
@@ -1,9 +1,9 @@
 // @flow
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { getTransaction } from 'selectors/transactions';
-import { injectAsyncReducers } from 'store';
 import { Redirect } from 'react-router-dom';
+import { getTransaction, getTransactionBalance } from 'selectors/transactions';
+import { injectAsyncReducers } from 'store';
 import transactionReducer from 'modules/transactions';
 import NavLink from 'components/NavLink';
 import TransactionItem from 'components/Transaction';
@@ -13,15 +13,21 @@ injectAsyncReducers({
   transactions: transactionReducer,
 });
 
-const Transaction = ({ transaction }) => (
-  <section>
-    <NavLink to="/budget" label="← Budget" styles={{}} />
-    {transaction ? <TransactionItem {...transaction} /> : <Redirect to="/budget" />}
-  </section>
-);
+const Transaction = ({ transaction, balance }) => {
+  // If no transaction with a matching ID was found, redirect to budget.
+  if (!transaction) return <Redirect to="/budget" />;
 
-const mapStateToProps = (state, props) => ({
-  transaction: getTransaction(state, props.id),
+  return (
+    <section>
+      <NavLink to="/budget" label="← Budget" styles={{}} />
+      <TransactionItem balance={balance} {...transaction} />
+    </section>
+  );
+};
+
+const mapStateToProps = (state, { id }) => ({
+  transaction: getTransaction(state, id),
+  balance: Math.abs(getTransactionBalance(state, id)),
 });
 
 export default connect(mapStateToProps)(Transaction);

--- a/app/routes/Transaction/index.js
+++ b/app/routes/Transaction/index.js
@@ -1,0 +1,14 @@
+// @flow
+import React, { Component } from 'react';
+import Chunk from 'components/Chunk';
+
+const loadTransactionContainer = () => import('containers/Transaction' /* webpackChunkName: "Transaction" */);
+
+class Transaction extends Component<{}> {
+  render() {
+    const { match: { params: { id } } } = this.props;
+    return <Chunk load={loadTransactionContainer} transaction={id} />;
+  }
+}
+
+export default Transaction;

--- a/app/routes/Transaction/index.js
+++ b/app/routes/Transaction/index.js
@@ -7,7 +7,7 @@ const loadTransactionContainer = () => import('containers/Transaction' /* webpac
 class Transaction extends Component<{}> {
   render() {
     const { match: { params: { id } } } = this.props;
-    return <Chunk load={loadTransactionContainer} transaction={id} />;
+    return <Chunk load={loadTransactionContainer} id={parseInt(id, 10)} />;
   }
 }
 

--- a/app/routes/Transaction/index.js
+++ b/app/routes/Transaction/index.js
@@ -1,10 +1,11 @@
 // @flow
 import React, { Component } from 'react';
+import type { RouteProps } from 'types';
 import Chunk from 'components/Chunk';
 
 const loadTransactionContainer = () => import('containers/Transaction' /* webpackChunkName: "Transaction" */);
 
-class Transaction extends Component<{}> {
+class Transaction extends Component<RouteProps> {
   render() {
     const { match: { params: { id } } } = this.props;
     return <Chunk load={loadTransactionContainer} id={parseInt(id, 10)} />;

--- a/app/selectors/__tests__/transactions-test.js
+++ b/app/selectors/__tests__/transactions-test.js
@@ -1,6 +1,7 @@
 import {
   sortTransactions,
   getTransactions,
+  getTransaction,
   getInflowBalance,
   getOutflowBalance,
   getFormattedBalance,
@@ -47,6 +48,22 @@ describe('getTransactions', () => {
     const expectedSelection = [];
 
     expect(getTransactions(state)).toEqual(expectedSelection);
+  });
+});
+
+describe('getTransaction', () => {
+  it('should return requested transaction from the state', () => {
+    const state = { transactions: [{ id: 1 }, { id: 2 }] };
+    const expectedSelection = { id: 1 };
+
+    expect(getTransaction(state, 1)).toEqual(expectedSelection);
+  });
+
+  it('should return null if the transaction doesn’t exists', () => {
+    const state = {};
+    const expectedSelection = null;
+
+    expect(getTransaction(state, 1)).toEqual(expectedSelection);
   });
 });
 

--- a/app/selectors/__tests__/transactions-test.js
+++ b/app/selectors/__tests__/transactions-test.js
@@ -4,6 +4,7 @@ import {
   getTransaction,
   getInflowBalance,
   getOutflowBalance,
+  getTransactionBalance,
   getFormattedBalance,
   getFormattedInflowBalance,
   getFormattedOutflowBalance,
@@ -130,6 +131,41 @@ describe('getOutflowBalance', () => {
     expect(getOutflowBalance.recomputations()).toEqual(1);
     expect(getOutflowBalance(state3)).toEqual(expectedSelection2);
     expect(getOutflowBalance.recomputations()).toEqual(2);
+  });
+});
+
+describe('getTransactionBalance', () => {
+  it('should return the sum of values of every transaction of the same type as the specified transaction', () => {
+    const state = { transactions: [{ id: 1, value: -10 }, { id: 2, value: -50 }, { id: 3, value: 70 }] };
+    const expectedSelection1 = -60;
+    const expectedSelection2 = 70;
+
+    expect(getTransactionBalance(state, 1)).toEqual(expectedSelection1);
+    expect(getTransactionBalance(state, 3)).toEqual(expectedSelection2);
+  });
+
+  it('should return null if the transaction doesn’t exists', () => {
+    const state = { transactions: [{ id: 1, value: 50 }] };
+    const expectedSelection = null;
+
+    expect(getTransactionBalance(state, 2)).toEqual(expectedSelection);
+  });
+
+  it('should not recompute if called twice with the same transactions in state', () => {
+    getTransactionBalance.resetRecomputations();
+
+    const state1 = { transactions: [{ id: 1, value: -10 }, { id: 2, value: -50 }, { id: 3, value: 70 }] };
+    const state2 = { transactions: state1.transactions };
+    const expectedSelection1 = -60;
+
+    const state3 = { transactions: [{ id: 1, value: -10 }] };
+    const expectedSelection2 = -10;
+
+    expect(getTransactionBalance(state1, 1)).toEqual(expectedSelection1);
+    expect(getTransactionBalance(state2, 1)).toEqual(expectedSelection1);
+    expect(getTransactionBalance.recomputations()).toEqual(1);
+    expect(getTransactionBalance(state3, 1)).toEqual(expectedSelection2);
+    expect(getTransactionBalance.recomputations()).toEqual(2);
   });
 });
 

--- a/app/selectors/transactions.js
+++ b/app/selectors/transactions.js
@@ -39,6 +39,9 @@ const applyCategoryName = (transactions: TransactionSummary[], categories) =>
 
 export const getTransactions = (state: State): Transaction[] => state.transactions || [];
 
+export const getTransaction = (state: State, id: number): Transaction =>
+  getTransactions(state).find(transaction => transaction.id === id);
+
 const getInflowTransactions = createSelector([getTransactions], transactions =>
   transactions.filter(item => item.value > 0)
 );

--- a/app/selectors/transactions.js
+++ b/app/selectors/transactions.js
@@ -40,7 +40,7 @@ const applyCategoryName = (transactions: TransactionSummary[], categories) =>
 export const getTransactions = (state: State): Transaction[] => state.transactions || [];
 
 export const getTransaction = (state: State, id: number): Transaction =>
-  getTransactions(state).find(transaction => transaction.id === id);
+  getTransactions(state).find(transaction => transaction.id === id) || null;
 
 const getInflowTransactions = createSelector([getTransactions], transactions =>
   transactions.filter(item => item.value > 0)

--- a/app/selectors/transactions.js
+++ b/app/selectors/transactions.js
@@ -60,6 +60,14 @@ export const getOutflowBalance = createSelector([getOutflowTransactions], transa
   totalTransactions(transactions)
 );
 
+export const getTransactionBalance = createSelector(
+  [getTransaction, getInflowBalance, getOutflowBalance],
+  (transaction, inflowBalance, outflowBalance) => {
+    if (!transaction) return null;
+    return transaction.value > 0 ? inflowBalance : outflowBalance;
+  }
+);
+
 export const getFormattedBalance = createSelector([getBalance], amount => formatAmount(amount, false));
 
 export const getFormattedInflowBalance = createSelector([getInflowBalance], amount => formatAmount(amount, false));

--- a/app/types/index.js
+++ b/app/types/index.js
@@ -5,7 +5,7 @@ export type HigherOrderComponent<RequiredProps: {}, ProvidedProps: {}> = <Origin
 
 export type RouteProps = {
   +match: {
-    +params?: {
+    +params: {
       +id?: number,
     },
   },

--- a/app/types/index.js
+++ b/app/types/index.js
@@ -2,3 +2,11 @@
 export type HigherOrderComponent<RequiredProps: {}, ProvidedProps: {}> = <OriginalProps: {}>(
   component: React.ComponentType<OriginalProps>
 ) => React.ComponentType<RequiredProps & $Diff<OriginalProps, ProvidedProps>>;
+
+export type RouteProps = {
+  +match: {
+    +params?: {
+      +id?: number,
+    },
+  },
+};

--- a/app/types/index.js
+++ b/app/types/index.js
@@ -6,7 +6,7 @@ export type HigherOrderComponent<RequiredProps: {}, ProvidedProps: {}> = <Origin
 export type RouteProps = {
   +match: {
     +params: {
-      +id?: number,
+      +id: ?string,
     },
   },
 };

--- a/app/utils/formatAmount.js
+++ b/app/utils/formatAmount.js
@@ -5,10 +5,14 @@ export type FormattedAmount = {
   isNegative: boolean,
 };
 
-export default function formatAmount(amount: number, showSign: boolean = true): FormattedAmount {
+export default function formatAmount(
+  amount: number,
+  showSign: boolean = true,
+  style: 'currency' | 'percent' = 'currency'
+): FormattedAmount {
   const isNegative = amount < 0;
   const formatValue = Math.abs(amount).toLocaleString('en-us', {
-    style: 'currency',
+    style,
     currency: 'USD',
   });
 


### PR DESCRIPTION
# Story

As a user, I want to see percentage of total budget an item is contributing with, so I can better understand statistics of my inflow or outflow items

## Proposed Changes

* Create detail page for transactions.
* Allow user to navigate to details page through Budgeting Grid.
* Page should have transaction description as the title.
* URL should reflect current transaction.
* Show budget percentage affected by transaction as a subtitle, with a green plus sign for inflows, red minus sign for outflows.
* Add a pie chart showing how much of the budget the item contributes to.
* Add back button to return to Budget page.
* Must be responsive.

## Screenshot

![screenshot](https://user-images.githubusercontent.com/1458873/37261469-82ddabc8-257b-11e8-9005-169c71d08bb8.gif)

## Checklist

* [x] Feature developed
* [x] Created/updated unit tests
* [x] Comments in code
* [ ] Documentation written
