### PR TITLE
View 

### DIFF
--- a/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<tr>
+<tr
+  onClick={[Function]}
+>
   <td>
     <div
       className="cellLabel"

--- a/app/components/BudgetGridRow/__tests__/index-test.js
+++ b/app/components/BudgetGridRow/__tests__/index-test.js
@@ -15,6 +15,8 @@ it('renders correctly', () => {
     2: 'School',
   };
 
-  const tree = renderer.create(<BudgetGridRow transaction={mockTransaction} categories={mockCategories} />).toJSON();
+  const tree = renderer
+    .create(<BudgetGridRow transaction={mockTransaction} categories={mockCategories} onClick={() => ({})} />)
+    .toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -8,16 +8,17 @@ import styles from './style.scss';
 type BudgetGridRowProps = {
   transaction: Transaction,
   categories: Categories,
+  onClick: Function
 };
 
-const BudgetGridRow = ({ transaction, categories }: BudgetGridRowProps) => {
+const BudgetGridRow = ({ transaction, categories, onClick }: BudgetGridRowProps) => {
   const amount = formatAmount(transaction.value);
   const amountCls = amount.isNegative ? styles.neg : styles.pos;
   const { id, categoryId, description } = transaction;
   const category = categories[categoryId];
 
   return (
-    <tr key={id}>
+    <tr key={id} onClick={onClick}>
       <td>
         <div className={styles.cellLabel}>Category</div>
         <div className={styles.cellContent}>{category}</div>

--- a/app/components/DonutChart/index.js
+++ b/app/components/DonutChart/index.js
@@ -19,6 +19,7 @@ type DonutChartProps = {
   color: Function,
   height: number,
   innerRatio: number,
+  shouldDisplayPiChart: boolean,
 };
 
 class DonutChart extends React.Component<DonutChartProps> {
@@ -27,6 +28,7 @@ class DonutChart extends React.Component<DonutChartProps> {
     height: 300,
     innerRatio: 4,
     dataValue: 'value',
+    shouldDisplayPiChart: false,
   };
 
   componentWillMount() {
@@ -44,9 +46,9 @@ class DonutChart extends React.Component<DonutChartProps> {
   }
 
   getPathArc = () => {
-    const { height, innerRatio } = this.props;
+    const { height, innerRatio, shouldDisplayPiChart } = this.props;
     return arc()
-      .innerRadius(height / innerRatio)
+      .innerRadius(shouldDisplayPiChart ? 1 : height / innerRatio)
       .outerRadius(height / 2);
   };
 

--- a/app/components/Transaction/index.js
+++ b/app/components/Transaction/index.js
@@ -10,12 +10,17 @@ const TransactionComponent = props => (
         {props.transaction.category} - {props.transaction.description}
       </h2>
       <div>{props.subtitle}</div>
+      <div>inflow: {props.inflow}</div>
+      <div>outflow: {props.outflow}</div>
     </div>
   </div>
 );
 TransactionComponent.propTypes = {
   transaction: PropTypes.object.isRequired,
   backToPreviousRoute: PropTypes.func.isRequired,
+  subtitle: PropTypes.element.isRequired,
+  inflow: PropTypes.number.isRequired,
+  outflow: PropTypes.number.isRequired,
 };
 
 TransactionComponent.defaultProps = {

--- a/app/components/Transaction/index.js
+++ b/app/components/Transaction/index.js
@@ -1,26 +1,30 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import DonutChart from '../DonutChart';
 
-const TransactionComponent = props => (
+import styles from './styles.scss';
+
+const TransactionComponent = ({ transaction, inflowPercentage, outflowPercentage, backToPreviousRoute, data }) => (
   <div>
-    <div>{JSON.stringify(props.transaction)}</div>
-    <button onClick={props.backToPreviousRoute}>Back</button>
+    <button onClick={backToPreviousRoute}>Back</button>
     <div>
       <h2>
-        {props.transaction.category} - {props.transaction.description}
+        {transaction.category} - {transaction.description}
       </h2>
-      <div>{props.subtitle}</div>
-      <div>inflow: {props.inflow}</div>
-      <div>outflow: {props.outflow}</div>
+      <div className={styles.subtitle}>
+        <div className={styles.pos}>+{inflowPercentage}</div>
+        <div className={styles.neg}>-{outflowPercentage}</div>
+      </div>
+      <DonutChart data={data} dataLabel="label" dataKey="id" shouldDisplayPiChart />
     </div>
   </div>
 );
 TransactionComponent.propTypes = {
   transaction: PropTypes.object.isRequired,
   backToPreviousRoute: PropTypes.func.isRequired,
-  subtitle: PropTypes.element.isRequired,
-  inflow: PropTypes.number.isRequired,
-  outflow: PropTypes.number.isRequired,
+  inflowPercentage: PropTypes.number.isRequired,
+  outflowPercentage: PropTypes.number.isRequired,
+  data: PropTypes.array.isRequired,
 };
 
 TransactionComponent.defaultProps = {

--- a/app/components/Transaction/index.js
+++ b/app/components/Transaction/index.js
@@ -1,26 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const TransactionComponent = props => {
-  console.log(props);
-  return (
+const TransactionComponent = props => (
+  <div>
+    <div>{JSON.stringify(props.transaction)}</div>
+    <button onClick={props.backToPreviousRoute}>Back</button>
     <div>
-      <button
-        onClick={() => {
-          props.backToPreviousRoute();
-          console.log('onclick');
-        }}
-      >
-        Back
-      </button>
-      <div>
-        <h2>
-          {props.transaction.category} - {props.transaction.description}
-        </h2>
-      </div>
+      <h2>
+        {props.transaction.category} - {props.transaction.description}
+      </h2>
+      <div>{props.subtitle}</div>
     </div>
-  );
-};
+  </div>
+);
 TransactionComponent.propTypes = {
   transaction: PropTypes.object.isRequired,
   backToPreviousRoute: PropTypes.func.isRequired,

--- a/app/components/Transaction/index.js
+++ b/app/components/Transaction/index.js
@@ -7,16 +7,22 @@ import styles from './styles.scss';
 const TransactionComponent = ({ transaction, inflowPercentage, outflowPercentage, backToPreviousRoute, data }) => (
   <div>
     <button onClick={backToPreviousRoute}>Back</button>
-    <div>
-      <h2>
-        {transaction.category} - {transaction.description}
-      </h2>
-      <div className={styles.subtitle}>
-        <div className={styles.pos}>+{inflowPercentage}</div>
-        <div className={styles.neg}>-{outflowPercentage}</div>
+    {transaction.value && (
+      <div>
+        <div className={styles.content}>
+          <div>
+            <h2>
+              {transaction.category} - {transaction.description}
+            </h2>
+          </div>
+          <div className={styles.subtitle}>
+            <div className={styles.pos}>+{inflowPercentage}</div>
+            <div className={styles.neg}>-{outflowPercentage}</div>
+          </div>
+        </div>
+        <DonutChart data={data} dataLabel="label" dataKey="id" shouldDisplayPiChart />
       </div>
-      <DonutChart data={data} dataLabel="label" dataKey="id" shouldDisplayPiChart />
-    </div>
+    )}
   </div>
 );
 TransactionComponent.propTypes = {

--- a/app/components/Transaction/index.js
+++ b/app/components/Transaction/index.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const TransactionComponent = props => {
+  console.log(props);
+  return (
+    <div>
+      <button
+        onClick={() => {
+          props.backToPreviousRoute();
+          console.log('onclick');
+        }}
+      >
+        Back
+      </button>
+      <div>
+        <h2>
+          {props.transaction.category} - {props.transaction.description}
+        </h2>
+      </div>
+    </div>
+  );
+};
+TransactionComponent.propTypes = {
+  transaction: PropTypes.object.isRequired,
+  backToPreviousRoute: PropTypes.func.isRequired,
+};
+
+TransactionComponent.defaultProps = {
+  transaction: {},
+};
+
+export default TransactionComponent;

--- a/app/components/Transaction/styles.scss
+++ b/app/components/Transaction/styles.scss
@@ -1,0 +1,17 @@
+@import 'theme/variables';
+
+.neg {
+  color: $red;
+  margin-left: 10px;
+}
+
+.pos {
+  color: $green;
+}
+
+.subtitle {
+  display: flex;
+  justify-content: flex-start;
+  flex-direction: row;
+  align-content: center;
+}

--- a/app/components/Transaction/styles.scss
+++ b/app/components/Transaction/styles.scss
@@ -9,9 +9,14 @@
   color: $green;
 }
 
+.content {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+}
 .subtitle {
   display: flex;
-  justify-content: flex-start;
   flex-direction: row;
-  align-content: center;
+  margin-bottom: 5%;
 }

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -4,6 +4,7 @@ import { Switch, Route, Redirect } from 'react-router-dom';
 
 import ErrorBoundary from 'components/ErrorBoundary';
 import AppError from 'components/AppError';
+import TransactionContainer from '../Transaction';
 import Header from 'components/Header';
 import Budget from 'routes/Budget';
 import Reports from 'routes/Reports';
@@ -17,6 +18,7 @@ const App = () => (
       <Switch>
         <Route path="/budget" component={Budget} />
         <Route path="/reports" component={Reports} />
+        <Route path="/transactions/:id" component={TransactionContainer} />
         <Redirect to="/budget" />
       </Switch>
     </main>

--- a/app/containers/BudgetGrid/index.js
+++ b/app/containers/BudgetGrid/index.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
 import { getTransactions } from 'selectors/transactions';
 import { getCategories } from 'selectors/categories';
 import EntryFormRow from 'containers/EntryFormRow';
@@ -11,17 +12,18 @@ import styles from './style.scss';
 type BudgetGridProps = {
   transactions: Transaction[],
   categories: Object,
+  history: Object,
 };
 
 export class BudgetGrid extends React.Component<BudgetGridProps> {
   static defaultProps = {
     transactions: [],
     categories: {},
+    history: { push: () => ({}) },
   };
 
   render() {
-    const { transactions, categories } = this.props;
-
+    const { transactions, categories, history } = this.props;
     return (
       <table className={styles.budgetGrid}>
         <thead>
@@ -33,7 +35,12 @@ export class BudgetGrid extends React.Component<BudgetGridProps> {
         </thead>
         <tbody>
           {transactions.map((transaction: Transaction): React.Element<any> => (
-            <BudgetGridRow key={transaction.id} transaction={transaction} categories={categories} />
+            <BudgetGridRow
+              key={transaction.id}
+              transaction={transaction}
+              categories={categories}
+              onClick={() => history.push(`/transactions/${transaction.id}`)}
+            />
           ))}
         </tbody>
         <tfoot>
@@ -49,4 +56,5 @@ const mapStateToProps = state => ({
   categories: getCategories(state),
 });
 
-export default connect(mapStateToProps)(BudgetGrid);
+const withRoutered = withRouter(BudgetGrid);
+export default connect(mapStateToProps)(withRoutered);

--- a/app/containers/Transaction/index.js
+++ b/app/containers/Transaction/index.js
@@ -2,21 +2,25 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
+import formatAmount from 'utils/formatAmount';
 import { getTransaction } from 'selectors/transactions';
 import TransactionComponent from '../../components/Transaction';
 
-// import styles from './style.scss';
-const TransactionContainer = props => (
-  <div>
-    <TransactionComponent
-      backToPreviousRoute={() => {
-        console.log('backToPreviousRoute');
-        props.history.goBack();
-      }}
-      transaction={props.transaction}
-    />
-  </div>
-);
+import styles from './style.scss';
+
+const TransactionContainer = props => {
+  const amount = formatAmount(props.transaction.value);
+  const amountCls = amount.isNegative ? styles.neg : styles.pos;
+  return (
+    <div>
+      <TransactionComponent
+        backToPreviousRoute={() => props.history.goBack()}
+        transaction={props.transaction}
+        subtitle={<div className={amountCls}>{amount.text}</div>}
+      />
+    </div>
+  );
+};
 TransactionContainer.propTypes = {
   history: PropTypes.shape({
     goBack: PropTypes.func,

--- a/app/containers/Transaction/index.js
+++ b/app/containers/Transaction/index.js
@@ -3,20 +3,22 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import formatAmount from 'utils/formatAmount';
-import { getTransaction } from 'selectors/transactions';
+import { getTransaction, getInflowBalance, getOutflowBalance } from 'selectors/transactions';
 import TransactionComponent from '../../components/Transaction';
-
 import styles from './style.scss';
 
 const TransactionContainer = props => {
   const amount = formatAmount(props.transaction.value);
   const amountCls = amount.isNegative ? styles.neg : styles.pos;
+  console.log(props);
   return (
     <div>
       <TransactionComponent
         backToPreviousRoute={() => props.history.goBack()}
         transaction={props.transaction}
         subtitle={<div className={amountCls}>{amount.text}</div>}
+        inflow={props.inflow}
+        outflow={props.outflow}
       />
     </div>
   );
@@ -25,6 +27,8 @@ TransactionContainer.propTypes = {
   history: PropTypes.shape({
     goBack: PropTypes.func,
   }).isRequired,
+  inflow: PropTypes.number.isRequired,
+  outflow: PropTypes.number.isRequired,
 };
 TransactionContainer.defaultProps = {
   match: {
@@ -35,6 +39,8 @@ TransactionContainer.defaultProps = {
 
 const mapStateToProps = (state, ownProps) => ({
   transaction: getTransaction(state, ownProps.match.params.id),
+  inflow: getInflowBalance(state),
+  outflow: getOutflowBalance(state),
 });
 
 export default connect(mapStateToProps)(TransactionContainer);

--- a/app/containers/Transaction/index.js
+++ b/app/containers/Transaction/index.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import { getTransaction } from 'selectors/transactions';
+import TransactionComponent from '../../components/Transaction';
+
+// import styles from './style.scss';
+const TransactionContainer = props => (
+  <div>
+    <TransactionComponent
+      backToPreviousRoute={() => {
+        console.log('backToPreviousRoute');
+        props.history.goBack();
+      }}
+      transaction={props.transaction}
+    />
+  </div>
+);
+TransactionContainer.propTypes = {
+  history: PropTypes.shape({
+    goBack: PropTypes.func,
+  }).isRequired,
+};
+TransactionContainer.defaultProps = {
+  match: {
+    params: {},
+  },
+  transaction: {},
+};
+
+const mapStateToProps = (state, ownProps) => ({
+  transaction: getTransaction(state, ownProps.match.params.id),
+});
+
+export default connect(mapStateToProps)(TransactionContainer);

--- a/app/containers/Transaction/index.js
+++ b/app/containers/Transaction/index.js
@@ -1,7 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import * as selectors from 'selectors/transactions';
+import {
+  getTransaction,
+  getInflowPercentage,
+  getOutflowPercentage,
+  getInflowBalance,
+  getOutflowBalance,
+} from 'selectors/transactions';
 import TransactionComponent from '../../components/Transaction';
 
 const TransactionContainer = props => {
@@ -38,11 +44,11 @@ TransactionContainer.defaultProps = {
 };
 
 const mapStateToProps = (state, ownProps) => ({
-  transaction: selectors.getTransaction(state, ownProps.match.params.id),
-  inflowPercentage: selectors.getInflowPercentage(state, ownProps.match.params.id),
-  outflowPercentage: selectors.getOutflowPercentage(state, ownProps.match.params.id),
-  inflow: selectors.getInflowBalance(state),
-  outflow: selectors.getOutflowBalance(state),
+  transaction: getTransaction(state, ownProps.match.params.id),
+  inflowPercentage: getInflowPercentage(state, ownProps.match.params.id),
+  outflowPercentage: getOutflowPercentage(state, ownProps.match.params.id),
+  inflow: getInflowBalance(state),
+  outflow: getOutflowBalance(state),
 });
 
 export default connect(mapStateToProps)(TransactionContainer);

--- a/app/containers/Transaction/index.js
+++ b/app/containers/Transaction/index.js
@@ -1,23 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-
-import formatAmount from 'utils/formatAmount';
-import {
-  getTransaction,
-  getInflowBalance,
-  getOutflowBalance,
-  sortTransactions,
-  getOutflowByCategoryName,
-} from 'selectors/transactions';
+import * as selectors from 'selectors/transactions';
 import TransactionComponent from '../../components/Transaction';
-import styles from './style.scss';
-import {
-  getInflowByCategoryName,
-  getInflowPercentage,
-  getOutflowPercentage,
-  getFormattedBalance,
-} from '../../selectors/transactions';
 
 const TransactionContainer = props => {
   const data = [
@@ -26,15 +11,13 @@ const TransactionContainer = props => {
   ];
   return (
     <div>
-      {props.transaction.value && (
-        <TransactionComponent
-          backToPreviousRoute={() => props.history.goBack()}
-          transaction={props.transaction}
-          outflowPercentage={props.outflowPercentage}
-          inflowPercentage={props.inflowPercentage}
-          data={data}
-        />
-      )}
+      <TransactionComponent
+        backToPreviousRoute={() => props.history.goBack()}
+        transaction={props.transaction}
+        outflowPercentage={props.outflowPercentage}
+        inflowPercentage={props.inflowPercentage}
+        data={data}
+      />
     </div>
   );
 };
@@ -55,11 +38,11 @@ TransactionContainer.defaultProps = {
 };
 
 const mapStateToProps = (state, ownProps) => ({
-  transaction: getTransaction(state, ownProps.match.params.id),
-  inflowPercentage: getInflowPercentage(state, ownProps.match.params.id),
-  outflowPercentage: getOutflowPercentage(state, ownProps.match.params.id),
-  inflow: getInflowBalance(state),
-  outflow: getOutflowBalance(state),
+  transaction: selectors.getTransaction(state, ownProps.match.params.id),
+  inflowPercentage: selectors.getInflowPercentage(state, ownProps.match.params.id),
+  outflowPercentage: selectors.getOutflowPercentage(state, ownProps.match.params.id),
+  inflow: selectors.getInflowBalance(state),
+  outflow: selectors.getOutflowBalance(state),
 });
 
 export default connect(mapStateToProps)(TransactionContainer);

--- a/app/containers/Transaction/index.js
+++ b/app/containers/Transaction/index.js
@@ -3,23 +3,38 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import formatAmount from 'utils/formatAmount';
-import { getTransaction, getInflowBalance, getOutflowBalance } from 'selectors/transactions';
+import {
+  getTransaction,
+  getInflowBalance,
+  getOutflowBalance,
+  sortTransactions,
+  getOutflowByCategoryName,
+} from 'selectors/transactions';
 import TransactionComponent from '../../components/Transaction';
 import styles from './style.scss';
+import {
+  getInflowByCategoryName,
+  getInflowPercentage,
+  getOutflowPercentage,
+  getFormattedBalance,
+} from '../../selectors/transactions';
 
 const TransactionContainer = props => {
-  const amount = formatAmount(props.transaction.value);
-  const amountCls = amount.isNegative ? styles.neg : styles.pos;
-  console.log(props);
+  const data = [
+    { label: 'Working Balance', id: 0, value: props.inflow + props.outflow },
+    { label: props.transaction.description, id: 1, value: Math.abs(props.transaction.value) },
+  ];
   return (
     <div>
-      <TransactionComponent
-        backToPreviousRoute={() => props.history.goBack()}
-        transaction={props.transaction}
-        subtitle={<div className={amountCls}>{amount.text}</div>}
-        inflow={props.inflow}
-        outflow={props.outflow}
-      />
+      {props.transaction.value && (
+        <TransactionComponent
+          backToPreviousRoute={() => props.history.goBack()}
+          transaction={props.transaction}
+          outflowPercentage={props.outflowPercentage}
+          inflowPercentage={props.inflowPercentage}
+          data={data}
+        />
+      )}
     </div>
   );
 };
@@ -27,18 +42,22 @@ TransactionContainer.propTypes = {
   history: PropTypes.shape({
     goBack: PropTypes.func,
   }).isRequired,
+  transaction: PropTypes.object.isRequired,
   inflow: PropTypes.number.isRequired,
   outflow: PropTypes.number.isRequired,
+  inflowPercentage: PropTypes.number.isRequired,
+  outflowPercentage: PropTypes.number.isRequired,
 };
 TransactionContainer.defaultProps = {
   match: {
     params: {},
   },
-  transaction: {},
 };
 
 const mapStateToProps = (state, ownProps) => ({
   transaction: getTransaction(state, ownProps.match.params.id),
+  inflowPercentage: getInflowPercentage(state, ownProps.match.params.id),
+  outflowPercentage: getOutflowPercentage(state, ownProps.match.params.id),
   inflow: getInflowBalance(state),
   outflow: getOutflowBalance(state),
 });

--- a/app/containers/Transaction/style.scss
+++ b/app/containers/Transaction/style.scss
@@ -1,0 +1,9 @@
+@import 'theme/variables';
+
+.neg {
+  color: $red;
+}
+
+.pos {
+  color: $green;
+}

--- a/app/containers/Transaction/style.scss
+++ b/app/containers/Transaction/style.scss
@@ -1,9 +1,0 @@
-@import 'theme/variables';
-
-.neg {
-  color: $red;
-}
-
-.pos {
-  color: $green;
-}

--- a/app/selectors/__tests__/transactions-test.js
+++ b/app/selectors/__tests__/transactions-test.js
@@ -8,6 +8,9 @@ import {
   getFormattedOutflowBalance,
   getOutflowByCategoryName,
   getInflowByCategoryName,
+  getOutflowPercentage,
+  getInflowPercentage,
+  getTransaction,
 } from '../transactions';
 
 // Mock 'selectors/categories' dependency
@@ -370,5 +373,126 @@ describe('getInflowByCategoryName', () => {
     expect(getInflowByCategoryName.recomputations()).toEqual(1);
     expect(getInflowByCategoryName(state3)).toEqual(expectedSelection2);
     expect(getInflowByCategoryName.recomputations()).toEqual(2);
+  });
+});
+describe('getTransaction', () => {
+  it('When state.transactions is not there, it should return empty object', () => {
+    const transaction = getTransaction({}, 0);
+    expect(transaction).toEqual({});
+  });
+  it('When transaction id == the id you are looking for, it should coerce and return valid transaction', () => {
+    const state = {
+      transactions: [{ id: '0', categoryId: 1 }],
+    };
+    const transaction = getTransaction(state, 0);
+    expect(transaction).toEqual(state.transactions[0]);
+  });
+});
+
+describe('getOutflowPercentage', () => {
+  it('When transactions does not have a corresponding transaction, it should return 0', () => {
+    const state = {
+      transactions: [{ value: 1, id: 1 }],
+    };
+    const value = getOutflowPercentage(state, 2);
+    expect(value).toEqual('0.00%');
+  });
+  it('When transactionValue / outflow is < 0, it should return 0.00%', () => {
+    const state = {
+      transactions: [
+        {
+          value: 100,
+          id: 0,
+        },
+        {
+          value: 200,
+          id: 1,
+        },
+        {
+          value: -400,
+          id: 2,
+        },
+      ],
+    };
+    const outflowPercentage = getOutflowPercentage(state, 1);
+    expect(outflowPercentage).toEqual(`0.00%`);
+  });
+  it('When transactionValue / outflow >= 0, it should return the percentage.', () => {
+    const state = {
+      transactions: [
+        {
+          value: 100,
+          id: 0,
+        },
+        {
+          value: 200,
+          id: 1,
+        },
+        {
+          value: -400,
+          id: 2,
+        },
+        {
+          value: -400,
+          id: 3,
+        },
+      ],
+    };
+    const outflowPercentage = getOutflowPercentage(state, 2);
+    expect(outflowPercentage).toEqual(`50.00%`);
+  });
+});
+
+describe('getInflowPercentage', () => {
+  it('When transactions does not have a corresponding transaction, it should return 0', () => {
+    const state = {
+      transactions: [{ value: 1, id: 1 }],
+    };
+    const value = getInflowPercentage(state, 2);
+    expect(value).toEqual('0.00%');
+  });
+  it('When transactionValue / inflow is > 0, it should return 0.00%', () => {
+    const state = {
+      transactions: [
+        {
+          value: 100,
+          id: 0,
+        },
+        {
+          value: 200,
+          id: 1,
+        },
+        {
+          value: -400,
+          id: 2,
+        },
+      ],
+    };
+    const outflowPercentage = getInflowPercentage(state, 2);
+    expect(outflowPercentage).toEqual(`0.00%`);
+  });
+  it('When transactionValue / outflow <= 0, it should return the percentage.', () => {
+    const state = {
+      transactions: [
+        {
+          value: 100,
+          id: 0,
+        },
+        {
+          value: 200,
+          id: 1,
+        },
+        {
+          value: -400,
+          id: 2,
+        },
+        {
+          value: -400,
+          id: 3,
+        },
+      ],
+    };
+    const outflowPercentage = getInflowPercentage(state, 1);
+    expect(outflowPercentage).toEqual(`66.67%`);
   });
 });

--- a/app/selectors/transactions.js
+++ b/app/selectors/transactions.js
@@ -26,7 +26,7 @@ function summarizeTransactions(transactions: Transaction[]): TransactionSummary[
   }, []);
 }
 
-export const sortTransactions = <T: { value: number }>(transactions: T[]): T[] => {
+export const sortTransactions = <T: { value: number }> (transactions: T[]): T[] => {
   const unsorted = [...transactions];
   return unsorted.sort((a, b) => b.value - a.value);
 };
@@ -36,6 +36,13 @@ const applyCategoryName = (transactions: TransactionSummary[], categories) =>
     transaction.category = categories[transaction.categoryId];
     return transaction;
   });
+
+export const getTransaction = (state: State, id: Number): Transaction => {
+  const filtered = (state.transactions || []).filter(t => t.id == id) || [];
+  const categoryNameApplied = applyCategoryName(filtered, state.categories);
+  return categoryNameApplied[0] || {}
+}
+
 
 export const getTransactions = (state: State): Transaction[] => state.transactions || [];
 

--- a/app/selectors/transactions.js
+++ b/app/selectors/transactions.js
@@ -26,7 +26,7 @@ function summarizeTransactions(transactions: Transaction[]): TransactionSummary[
   }, []);
 }
 
-export const sortTransactions = <T: { value: number }>(transactions: T[]): T[] => {
+export const sortTransactions = <T: { value: number }> (transactions: T[]): T[] => {
   const unsorted = [...transactions];
   return unsorted.sort((a, b) => b.value - a.value);
 };
@@ -38,6 +38,8 @@ const applyCategoryName = (transactions: TransactionSummary[], categories) =>
   });
 
 export const getTransaction = (state: State, id: Number): Transaction => {
+  // use == for coercion
+  // eslint-disable-next-line eqeqeq
   const filtered = (state.transactions || []).filter(t => t.id == id) || [];
   const categoryNameApplied = applyCategoryName(filtered, getCategories(state));
   return categoryNameApplied[0] || {};
@@ -85,21 +87,21 @@ export const getInflowByCategoryName = createSelector(getInflowByCategory, getCa
   applyCategoryName(trans, cat)
 );
 
-const formatAsPercentage = decimalNumber => `${Number.parseFloat(decimalNumber * 100).toFixed(2)}%`;
+const formatAsPercentage = (decimalNumber: Number) => `${Number.parseFloat(decimalNumber * 100).toFixed(2)}%`;
 
 const getPercentage = ({ state, transactionId, selector, valueDeterminer }) => {
   const { value: transactionValue } = getTransaction(state, transactionId);
-  const flow = selector(state);
-  const value = transactionValue / flow;
+  const flow: Number = selector(state);
+  const value: Number = transactionValue / flow;
   return formatAsPercentage(valueDeterminer(isNaN(value) ? 0 : value));
 };
 
-export const getOutflowPercentage = (state, transactionId) =>
+export const getOutflowPercentage = (state: State, transactionId: Number) =>
   getPercentage({
     state,
     transactionId,
     selector: getOutflowBalance,
-    valueDeterminer: value => (value < 0 ? 0 : value),
+    valueDeterminer: (value: Number) => (value < 0 ? 0 : value),
   });
 
 export const getInflowPercentage = (state: State, transactionId: Number) =>
@@ -107,5 +109,5 @@ export const getInflowPercentage = (state: State, transactionId: Number) =>
     state,
     transactionId,
     selector: getInflowBalance,
-    valueDeterminer: value => (value > 0 ? value : 0),
+    valueDeterminer: (value: Number) => (value > 0 ? value : 0),
   });

--- a/app/selectors/transactions.js
+++ b/app/selectors/transactions.js
@@ -26,7 +26,7 @@ function summarizeTransactions(transactions: Transaction[]): TransactionSummary[
   }, []);
 }
 
-export const sortTransactions = <T: { value: number }> (transactions: T[]): T[] => {
+export const sortTransactions = <T: { value: number }>(transactions: T[]): T[] => {
   const unsorted = [...transactions];
   return unsorted.sort((a, b) => b.value - a.value);
 };
@@ -40,9 +40,8 @@ const applyCategoryName = (transactions: TransactionSummary[], categories) =>
 export const getTransaction = (state: State, id: Number): Transaction => {
   const filtered = (state.transactions || []).filter(t => t.id == id) || [];
   const categoryNameApplied = applyCategoryName(filtered, state.categories);
-  return categoryNameApplied[0] || {}
-}
-
+  return categoryNameApplied[0] || {};
+};
 
 export const getTransactions = (state: State): Transaction[] => state.transactions || [];
 
@@ -85,3 +84,27 @@ export const getOutflowByCategoryName = createSelector(getOutflowByCategory, get
 export const getInflowByCategoryName = createSelector(getInflowByCategory, getCategories, (trans, cat) =>
   applyCategoryName(trans, cat)
 );
+
+const formatAsPercentage = decimalNumber => `${Number.parseFloat(decimalNumber * 100).toFixed(2)}%`;
+const getPercentage = ({ state, transactionId, selector, valueDeterminer }) => {
+  const { value: transactionValue } = getTransaction(state, transactionId);
+  const flow = selector(state);
+  const value = transactionValue / flow;
+  return formatAsPercentage(valueDeterminer(value));
+};
+
+export const getOutflowPercentage = (state, transactionId) =>
+  getPercentage({
+    state,
+    transactionId,
+    selector: getOutflowBalance,
+    valueDeterminer: value => (value < 0 ? 0 : value),
+  });
+
+export const getInflowPercentage = (state, transactionId) =>
+  getPercentage({
+    state,
+    transactionId,
+    selector: getInflowBalance,
+    valueDeterminer: value => (value > 0 ? value : 0),
+  });

--- a/app/selectors/transactions.js
+++ b/app/selectors/transactions.js
@@ -39,7 +39,7 @@ const applyCategoryName = (transactions: TransactionSummary[], categories) =>
 
 export const getTransaction = (state: State, id: Number): Transaction => {
   const filtered = (state.transactions || []).filter(t => t.id == id) || [];
-  const categoryNameApplied = applyCategoryName(filtered, state.categories);
+  const categoryNameApplied = applyCategoryName(filtered, getCategories(state));
   return categoryNameApplied[0] || {};
 };
 
@@ -86,11 +86,12 @@ export const getInflowByCategoryName = createSelector(getInflowByCategory, getCa
 );
 
 const formatAsPercentage = decimalNumber => `${Number.parseFloat(decimalNumber * 100).toFixed(2)}%`;
+
 const getPercentage = ({ state, transactionId, selector, valueDeterminer }) => {
   const { value: transactionValue } = getTransaction(state, transactionId);
   const flow = selector(state);
   const value = transactionValue / flow;
-  return formatAsPercentage(valueDeterminer(value));
+  return formatAsPercentage(valueDeterminer(isNaN(value) ? 0 : value));
 };
 
 export const getOutflowPercentage = (state, transactionId) =>
@@ -101,7 +102,7 @@ export const getOutflowPercentage = (state, transactionId) =>
     valueDeterminer: value => (value < 0 ? 0 : value),
   });
 
-export const getInflowPercentage = (state, transactionId) =>
+export const getInflowPercentage = (state: State, transactionId: Number) =>
   getPercentage({
     state,
     transactionId,


### PR DESCRIPTION
## Proposed Changes

Adds the ability for a user to see an individual transaction and what percent of the outflow/inflow percent it takes up.

I assumed that when it is decrease in budget, that there is no percent change for inflow, and when there is a increase in budget, that there is no percent change for outflow

## Screenshot
![image](https://user-images.githubusercontent.com/10186520/39554330-367ca4e4-4e40-11e8-9868-71290559de1d.png)
![image](https://user-images.githubusercontent.com/10186520/39554337-3c8f3ff4-4e40-11e8-99f3-17b47110cbf0.png)

...



## Checklist

* [x] Feature developed
* [x] Created/updated unit tests
* [] Comments in code
* [ ] Documentation written
